### PR TITLE
Provide example of combining createAction with createReducer

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,18 @@ function counterReducer(state = 0, action) {
 }
 ```
 
+Since action creators returned by `createAction` have `toString()` overridden, they can be used in `createReducer` as a key in the `actionsMap`:
+
+```js
+// reducer.js
+import { createReducer } from 'redux-starter-kit'
+import { increment } from './actions'
+
+const counterReducer = createReducer(0, {
+  [increment]: (state, action) => state + action.payload
+})
+```
+
 #### `createSlice`
 
 A function that accepts an initial state, an object full of reducer functions, and optionally a "slice name", and automatically generates action creators, action types, and selectors that correspond to the reducers and state.


### PR DESCRIPTION
The power of action creators returned by createAction lies in the `toString()` override when battling boilerplate for action constants.

This provides an example of using an action creator as the key in the `actionsMap` provided to `createReducer`