### PR TITLE
Correct example code in readme for createSlice

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ const counter = createSlice({
   reducers: {
     increment: state => state + 1,
     decrement: state => state - 1,
-    multiply: (state, action) => state * payload
+    multiply: (state, action) => state * action.payload
   }
 })
 
@@ -240,7 +240,7 @@ const user = createSlice({
   slice: 'user',
   initialState: { name: '' },
   reducers: {
-    setUserName: (state, payload) => {
+    setUserName: (state, action) => {
       state.name = action.payload // mutate the state all you want with immer
     }
   }


### PR DESCRIPTION
The readme has two code examples for `createSlice` which have two minor errors in them.