### PR TITLE
createReducer with optional slice parameter

### DIFF
--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -1,7 +1,7 @@
 import createNextState from 'immer'
 
-export function createReducer(initialState, actionsMap) {
-  return function(state = initialState, action) {
+export function createReducer(initialState, actionsMap, slice = '') {
+  const reducer = function(state = initialState, action) {
     return createNextState(state, draft => {
       const caseReducer = actionsMap[action.type]
 
@@ -12,4 +12,9 @@ export function createReducer(initialState, actionsMap) {
       return draft
     })
   }
+  if (typeof slice !== 'string') {
+    slice = ''
+  }
+  reducer.toString = () => slice
+  return reducer
 }

--- a/src/createReducer.test.js
+++ b/src/createReducer.test.js
@@ -50,6 +50,17 @@ describe('createReducer', () => {
 
     behavesLikeReducer(todosReducer)
   })
+
+  describe('given a slice, reducer.toString()', () => {
+    it('should return the slice', () => {
+      const reducer = createReducer([], {}, 'todo')
+      expect(String(reducer)).toBe('todo')
+    })
+    it('should return an empty string when provided slice is empty or not a string', () => {
+      const reducer = createReducer([], {})
+      expect(String(reducer)).toBe('')
+    })
+  })
 })
 
 function behavesLikeReducer(todosReducer) {

--- a/src/createSlice.js
+++ b/src/createSlice.js
@@ -12,7 +12,7 @@ export function createSlice({ slice = '', reducers = {}, initialState }) {
     return map
   }, {})
 
-  const reducer = createReducer(initialState, reducerMap)
+  const reducer = createReducer(initialState, reducerMap, slice)
 
   const actionMap = actionKeys.reduce((map, action) => {
     const type = getType(slice, action)

--- a/src/createSlice.test.js
+++ b/src/createSlice.test.js
@@ -77,6 +77,10 @@ describe('createSlice', () => {
       expect(reducer(undefined, actions.increment())).toEqual(1)
     })
 
+    it('should return the correct type of the reducer', () => {
+      expect(String(reducer)).toEqual('cool')
+    })
+
     it('should create selector with correct name', () => {
       expect(selectors.hasOwnProperty('getCool')).toBe(true)
     })


### PR DESCRIPTION
Adding the slice as an optional parameter to `createReducer` allows the slice to be defined once (in the reducer) and reused within `combineReducers` and selectors.