### PR TITLE
Action stack traces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6287,9 +6287,9 @@
       }
     },
     "redux-devtools-extension": {
-      "version": "2.13.5",
-      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.5.tgz",
-      "integrity": "sha512-QQ9BRy77oURHMdGys9rfQcCQDzXZ1T4oW+eUyE5Cg7DNVau69HJzc4YNDMOmpi0Dzpi1zOQgQ2rUpgJta4Lfqg=="
+      "version": "2.13.7",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.7.tgz",
+      "integrity": "sha512-F2GlWMWxCTJGRjJ+GSZcGDcVAj6Pbf77FKb4C9S8eni5Eah6UBGNwxNj8K1MTtmItdZH1Wx+EvIifHN2KKcQrw=="
     },
     "redux-immutable-state-invariant": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "immer": "^1.1.3",
     "redux": "^4.0.0",
-    "redux-devtools-extension": "^2.13.3",
+    "redux-devtools-extension": "^2.13.7",
     "redux-immutable-state-invariant": "^2.1.0",
     "redux-thunk": "^2.2.0",
     "selectorator": "^3.3.0"

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -45,9 +45,16 @@ export function configureStore(options = {}) {
 
   const middlewareEnhancer = applyMiddleware(...middleware)
 
-  const storeEnhancers = [middlewareEnhancer, ...enhancers]
+  let finalCompose = compose
 
-  let finalCompose = devTools ? composeWithDevTools : compose
+  if(devTools) {
+    finalCompose = composeWithDevTools({
+        // Enable capture of stack traces for dispatched Redux actions
+        trace : !IS_PRODUCTION
+    })
+  }
+
+  const storeEnhancers = [middlewareEnhancer, ...enhancers]
 
   const composedEnhancer = finalCompose(...storeEnhancers)
 


### PR DESCRIPTION
Turn on action stack traces in the Redux DevTools Extension, per https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#trace .