### PR TITLE
Fix: null is no longer flagged as non-serializable

### DIFF
--- a/src/serializableStateInvariantMiddleware.js
+++ b/src/serializableStateInvariantMiddleware.js
@@ -3,12 +3,12 @@ import isPlainObject from './isPlainObject'
 export function isPlain(val) {
   return (
     typeof val === 'undefined' ||
+    val === null ||
     typeof val === 'string' ||
     typeof val === 'boolean' ||
     typeof val === 'number' ||
     Array.isArray(val) ||
-    isPlainObject(val) ||
-    val === null
+    isPlainObject(val) 
   )
 }
 

--- a/src/serializableStateInvariantMiddleware.js
+++ b/src/serializableStateInvariantMiddleware.js
@@ -7,8 +7,8 @@ export function isPlain(val) {
     typeof val === 'boolean' ||
     typeof val === 'number' ||
     Array.isArray(val) ||
-    val === null ||
-    isPlainObject(val)
+    isPlainObject(val) ||
+    val === null
   )
 }
 
@@ -66,11 +66,7 @@ export default function createSerializableStateInvariantMiddleware(
   const { isSerializable = isPlain } = options
 
   return storeAPI => next => action => {
-    const foundActionNonSerializableValue = findNonSerializableValue(
-      action,
-      [],
-      isSerializable
-    )
+    const foundActionNonSerializableValue = findNonSerializableValue(action, [], isSerializable)
 
     if (foundActionNonSerializableValue) {
       const { keyPath, value } = foundActionNonSerializableValue

--- a/src/serializableStateInvariantMiddleware.js
+++ b/src/serializableStateInvariantMiddleware.js
@@ -7,6 +7,7 @@ export function isPlain(val) {
     typeof val === 'boolean' ||
     typeof val === 'number' ||
     Array.isArray(val) ||
+    val === null ||
     isPlainObject(val)
   )
 }
@@ -65,7 +66,11 @@ export default function createSerializableStateInvariantMiddleware(
   const { isSerializable = isPlain } = options
 
   return storeAPI => next => action => {
-    const foundActionNonSerializableValue = findNonSerializableValue(action, [], isSerializable)
+    const foundActionNonSerializableValue = findNonSerializableValue(
+      action,
+      [],
+      isSerializable
+    )
 
     if (foundActionNonSerializableValue) {
       const { keyPath, value } = foundActionNonSerializableValue


### PR DESCRIPTION
Fixes issue #67 

Adds a strict equality check for null in isPlain