### PR TITLE
Basic Typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,83 @@
-import { Action, ActionCreator } from 'redux'
+import {
+  Action,
+  ActionCreator,
+  Reducer,
+  AnyAction,
+  Middleware,
+  StoreEnhancer,
+  ReducersMapObject,
+  Store
+} from 'redux'
 
 // The `redux-starter-kit` typings are a superset of the `redux` typings.
-export * from 'redux'
+export {
+  Action,
+  ActionCreator,
+  AnyAction,
+  Middleware,
+  Reducer,
+  ReducersMapObject,
+  Store,
+  StoreEnhancer
+} from 'redux'
+
+/* configureStore() */
+
+/**
+ * A configuration object that can be passed to `configureStore()`.
+ */
+export interface StoreConfiguration<S, A extends Action = AnyAction> {
+  /**
+   * A single reducer function that will be used as the root reducer, or an
+   * object of slice reducers that will be passed to `combineReducers()`.
+   */
+  reducer: Reducer<S, A> | ReducersMapObject<S, A>
+
+  /**
+   * An array of Redux middlewares. If not supplied, defaults to just
+   * `redux-thunk`.
+   */
+  middleware?: Middleware[]
+
+  /**
+   * Whether to enable Redux DevTools integration. Defaults to `true`.
+   */
+  devTools?: boolean
+
+  /**
+   * The initial state. You may optionally specify it to hydrate the state
+   * from the server in universal apps, or to restore a previously serialized
+   * user session. If you use `combineReducers()` to produce the root reducer
+   * function (either directly or indirectly by passing an object as `reducer`),
+   * this must be an object with the same shape as the reducer map keys.
+   */
+  preloadedState?: S
+
+  /**
+   * The store enhancer. See `createStore()`. If you only need to add
+   * middleware, you can use the `middleware` parameter instaead.
+   */
+  enhancer?: StoreEnhancer
+}
+
+/**
+ * A friendlier abstraction over the standard Redux `createStore()` function.
+ *
+ * @param config The store configuration.
+ * @returns A configured Redux store.
+ */
+export function configureStore<S, A extends Action = AnyAction>(
+  config: StoreConfiguration<S, A>
+): Store<S, A>
+
+/* getDefaultMiddleware() */
+
+/**
+ * Returns any array containing the default middleware installed by
+ * `configureStore`. Useful if you want to configure your store with a custom
+ * `middleware` array but still keep the default set.
+ */
+export function getDefaultMiddleware(): Middleware[]
 
 /* createAction() */
 
@@ -28,5 +104,3 @@ export interface PayloadAction<P = any, T = any> extends Action<T> {
 export function createAction<P = any, T = any>(
   type: T
 ): ActionCreator<PayloadAction<P, T>>
-
-/* Reducers */

--- a/index.d.ts
+++ b/index.d.ts
@@ -138,3 +138,75 @@ export function createReducer<S, A extends Action = AnyAction>(
   initialState: S,
   actionsMap: ActionHandlersMapObject<S, A>
 ): Reducer<S, A>
+
+/* createSlice() */
+
+/**
+ * A *slice* bundles a reducer, creators for the actions handled by that
+ * reducer, and selectors for the reducer's state.
+ */
+export interface Slice<
+  S,
+  A extends Action = AnyAction,
+  AT extends string = string
+> {
+  /**
+   * The slice's reducer.
+   */
+  reducer: Reducer<S, A>
+
+  /**
+   * Action creators for the types of actions that are handled by the slice
+   * reducer.
+   */
+  actions: { [type in AT]: ActionCreator<PayloadAction> }
+
+  /**
+   * Selectors for the slice reducer state. `createSlice()` inserts a single
+   * selector that returns the entire slice state and whose name is
+   * automatically derived from the slice name (e.g., `getCounter` for a slice
+   * named `counter`).
+   */
+  selectors: { [key: string]: (state: any) => S }
+}
+
+/**
+ * A configuration object for `createSlice()`.
+ */
+export interface SliceConfiguration<
+  S,
+  A extends Action = AnyAction,
+  AT extends string = string
+> {
+  /**
+   * The slice's name. Used to namespace the generated action types and to
+   * name the selector for retrieving the reducer's state.
+   */
+  slice?: string
+
+  /**
+   * The initial state to be returned by the slice reducer.
+   */
+  initialState: S
+
+  /**
+   * A mapping from action types to handlers (reducer functions) for these
+   * actions. For every action type, a matching action creator will be
+   * generated.
+   */
+  reducers: { [key in AT]: ActionHandler<S, A> }
+}
+
+/**
+ * A function that accepts an initial state, an object full of reducer
+ * functions, and optionally a "slice name", and automatically generates
+ * action creators, action types, and selectors that correspond to the
+ * reducers and state.
+ *
+ * The reducers are wrapped with `createReducer()`.
+ */
+export function createSlice<
+  S,
+  A extends Action = AnyAction,
+  AT extends string = string
+>(config: SliceConfiguration<S, A, AT>): Slice<S, A, AT>

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,6 @@ import {
   Store
 } from 'redux'
 
-// The `redux-starter-kit` typings are a superset of the `redux` typings.
 export {
   Action,
   ActionCreator,
@@ -104,3 +103,38 @@ export interface PayloadAction<P = any, T = any> extends Action<T> {
 export function createAction<P = any, T = any>(
   type: T
 ): ActionCreator<PayloadAction<P, T>>
+
+/* createReducer() */
+
+/**
+ * An *action handler* is a reducer for a speficic action type passed to
+ * `createReducer()`. In contrast to a normal Redux reducer, it is never
+ * called with an `undefined` state because the initial state is explicitly
+ * passed as the first argument to `createReducer()`.
+ */
+export interface ActionHandler<S, A> {
+  (state: S, action: A): S
+}
+
+/**
+ * A mapping from action types to action handlers, meant to be passed to
+ * `createReducer()`.
+ */
+export interface ActionHandlersMapObject<S, A extends Action = AnyAction> {
+  [actionType: string]: ActionHandler<S, A>
+}
+
+/**
+ * A utility function to create reducers that handle specific action types.
+ * case reducer functions. Internally, it uses the `immer` library, so you
+ * can write code in your case reducers that mutates the existing state value,
+ * and it will correctly generate immutably-updated state values instead.
+ *
+ * @param initialState The initial state to be returned by the reducer.
+ * @param actionsMap A mapping from action types to action handlers
+ *   (action-type-specific reducer functions).
+ */
+export function createReducer<S, A extends Action = AnyAction>(
+  initialState: S,
+  actionsMap: ActionHandlersMapObject<S, A>
+): Reducer<S, A>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,32 @@
+import { Action, ActionCreator } from 'redux'
+
+// The `redux-starter-kit` typings are a superset of the `redux` typings.
+export * from 'redux'
+
+/* createAction() */
+
+/**
+ * An action with an associated payload. The type of action returned by
+ * action creators that are generated using {@link createAction}.
+ *
+ * @template P The type of the action's payload.
+ * @template T the type of the action's `type` tag.
+ */
+export interface PayloadAction<P = any, T = any> extends Action<T> {
+  payload: P
+}
+
+/**
+ * A utility function to create an action creator for the given action type
+ * string. The action creator accepts a single argument, which will be included
+ * in the action object as a field called payload. The action creator function
+ * will also have its toString() overriden so that it returns the action type,
+ * allowing it to be used in reducer logic that is looking for that action type.
+ *
+ * @param type
+ */
+export function createAction<P = any, T = any>(
+  type: T
+): ActionCreator<PayloadAction<P, T>>
+
+/* Reducers */

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,6 +91,11 @@ export interface PayloadAction<P = any, T = any> extends Action<T> {
   payload: P
 }
 
+export interface PayloadActionCreator<P = any, T = any> {
+  (): Action<T>
+  (payload: P): PayloadAction<P, T>
+}
+
 /**
  * A utility function to create an action creator for the given action type
  * string. The action creator accepts a single argument, which will be included
@@ -102,7 +107,7 @@ export interface PayloadAction<P = any, T = any> extends Action<T> {
  */
 export function createAction<P = any, T = any>(
   type: T
-): ActionCreator<PayloadAction<P, T>>
+): PayloadActionCreator<P, T>
 
 /* createReducer() */
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ export {
   Store,
   StoreEnhancer
 } from 'redux'
+export { default as createSelector } from 'selectorator'
 
 /* configureStore() */
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,9 @@ export {
   Reducer,
   ReducersMapObject,
   Store,
-  StoreEnhancer
+  StoreEnhancer,
+  combineReducers,
+  compose
 } from 'redux'
 export { default as createSelector } from 'selectorator'
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ export {
   compose
 } from 'redux'
 export { default as createSelector } from 'selectorator'
+export { produce as createNextState } from 'immer'
 
 /* configureStore() */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2635,14 +2635,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2657,20 +2655,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2787,8 +2782,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2800,7 +2794,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2815,7 +2808,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2823,14 +2815,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2849,7 +2839,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2930,8 +2919,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2943,7 +2931,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3065,7 +3052,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7126,6 +7112,21 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typescript": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
+      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "dev": true
+    },
+    "typings-tester": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/typings-tester/-/typings-tester-0.3.2.tgz",
+      "integrity": "sha512-HjGoAM2UoGhmSKKy23TYEKkxlphdJFdix5VvqWFLzH1BJVnnwG38tpC6SXPgqhfFGfHY77RlN1K8ts0dbWBQ7A==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.12.2"
+      }
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "rollup-plugin-babel": "^3.0.3",
     "rollup-plugin-commonjs": "^8.3.0",
     "rollup-plugin-node-resolve": "^3.0.3",
-    "rollup-plugin-replace": "^2.1.0"
+    "rollup-plugin-replace": "^2.1.0",
+    "typescript": "^3.2.2",
+    "typings-tester": "^0.3.2"
   },
   "scripts": {
     "build": "rollup -c",
@@ -37,7 +39,8 @@
     "test": "jest"
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "dependencies": {
     "immer": "^1.9.3",

--- a/typing-tests/typescript.test.js
+++ b/typing-tests/typescript.test.js
@@ -1,0 +1,5 @@
+import { checkDirectory } from 'typings-tester'
+
+test('TypeScript definitions', () => {
+  checkDirectory(`${__dirname}/typescript`)
+})

--- a/typing-tests/typescript/configureStore.ts
+++ b/typing-tests/typescript/configureStore.ts
@@ -1,0 +1,124 @@
+import { applyMiddleware } from 'redux'
+import {
+  AnyAction,
+  configureStore,
+  Middleware,
+  PayloadAction,
+  Reducer,
+  Store
+} from 'redux-starter-kit'
+
+/*
+ * Test: configureStore() requires a valid reducer or reducer map.
+ */
+{
+  configureStore({
+    reducer: (state, action) => 0
+  })
+
+  configureStore({
+    reducer: {
+      counter1: () => 0,
+      counter2: () => 1
+    }
+  })
+
+  // typings:expect-error
+  configureStore({ reducer: 'not a reducer' })
+
+  // typings:expect-error
+  configureStore({ reducer: { a: 'not a reducer' } })
+
+  // typings:expect-error
+  configureStore({})
+}
+
+/*
+ * Test: configureStore() infers the store state type.
+ */
+{
+  const reducer: Reducer<number> = () => 0
+  const store = configureStore({ reducer })
+  const numberStore: Store<number, AnyAction> = store
+
+  // typings:expect-error
+  const stringStore: Store<string, AnyAction> = store
+}
+
+/*
+ * Test: configureStore() infers the store action type.
+ */
+{
+  const reducer: Reducer<number, PayloadAction<number>> = () => 0
+  const store = configureStore({ reducer })
+  const numberStore: Store<number, PayloadAction<number>> = store
+
+  // typings:expect-error
+  const stringStore: Store<number, PayloadAction<string>> = store
+}
+
+/*
+ * Test: configureStore() accepts middleware array.
+ */
+{
+  const middleware: Middleware = store => next => next
+
+  configureStore({
+    reducer: () => 0,
+    middleware: [middleware]
+  })
+
+  // typings:expect-error
+  configureStore({
+    reducer: () => 0,
+    middleware: ['not middleware']
+  })
+}
+
+/*
+ * Test: configureStore() accepts devTools flag.
+ */
+{
+  configureStore({
+    reducer: () => 0,
+    devTools: true
+  })
+
+  // typings:expect-error
+  configureStore({
+    reducer: () => 0,
+    devTools: 'true'
+  })
+}
+
+/*
+ * Test: configureStore() accepts preloadedState.
+ */
+{
+  configureStore({
+    reducer: () => 0,
+    preloadedState: 0
+  })
+
+  // typings:expect-error
+  configureStore({
+    reducer: () => 0,
+    preloadedState: 'non-matching state type'
+  })
+}
+
+/*
+ * Test: configureStore() accepts store enhancer.
+ */
+{
+  configureStore({
+    reducer: () => 0,
+    enhancer: applyMiddleware(store => next => next)
+  })
+
+  // typings:expect-error
+  configureStore({
+    reducer: () => 0,
+    enhancer: 'not a store enhancer'
+  })
+}

--- a/typing-tests/typescript/createAction.ts
+++ b/typing-tests/typescript/createAction.ts
@@ -1,4 +1,11 @@
-import { createAction, PayloadAction, ActionCreator } from 'redux-starter-kit'
+import {
+  createAction,
+  PayloadAction,
+  ActionCreator,
+  PayloadActionCreator,
+  Action,
+  AnyAction
+} from 'redux-starter-kit'
 
 /* PayloadAction */
 
@@ -35,6 +42,40 @@ import { createAction, PayloadAction, ActionCreator } from 'redux-starter-kit'
   const action3: PayloadAction<number, number> = { type: '', payload: 5 }
 }
 
+/* PayloadActionCreator */
+
+/*
+ * Test: PayloadActionCreator returns Action or PayloadAction depending
+ * on whether a payload is passed.
+ */
+{
+  const actionCreator: PayloadActionCreator = (payload?: number) => ({
+    type: 'action',
+    payload
+  })
+
+  let action: Action
+  let payloadAction: PayloadAction
+
+  action = actionCreator()
+  action = actionCreator(1)
+  payloadAction = actionCreator(1)
+
+  // typings:expect-error
+  payloadAction = actionCreator()
+}
+
+/*
+ * Test: PayloadActionCreator is compatible with ActionCreator.
+ */
+{
+  const payloadActionCreator: PayloadActionCreator = (payload?: number) => ({
+    type: 'action',
+    payload
+  })
+  const actionCreator: ActionCreator<AnyAction> = payloadActionCreator
+}
+
 /* createAction() */
 
 /*
@@ -42,10 +83,10 @@ import { createAction, PayloadAction, ActionCreator } from 'redux-starter-kit'
  */
 {
   const increment = createAction<number>('increment')
-  const incrementNumber: ActionCreator<PayloadAction<number>> = increment
+  const n: number = increment(1).payload
 
   // typings:expect-error
-  const incrementString: ActionCreator<PayloadAction<string>> = increment
+  const s: string = increment(1).payload
 }
 
 /*
@@ -53,6 +94,6 @@ import { createAction, PayloadAction, ActionCreator } from 'redux-starter-kit'
  */
 {
   const increment = createAction('increment')
-  const incrementNumber: ActionCreator<PayloadAction<number>> = increment
-  const incrementString: ActionCreator<PayloadAction<string>> = increment
+  const n: number = increment(1).payload
+  const s: string = increment(1).payload
 }

--- a/typing-tests/typescript/createAction.ts
+++ b/typing-tests/typescript/createAction.ts
@@ -1,0 +1,58 @@
+import { createAction, PayloadAction, ActionCreator } from 'redux-starter-kit'
+
+/* PayloadAction */
+
+/*
+ * Test: PayloadAction has type parameter for the payload.
+ */
+{
+  const action: PayloadAction<number> = { type: '', payload: 5 }
+  const numberPayload: number = action.payload
+
+  // typings:expect-error
+  const stringPayload: string = action.payload
+}
+
+/*
+ * Test: PayloadAction type parameter is optional (defaults to `any`).
+ */
+{
+  const action: PayloadAction = { type: '', payload: 5 }
+  const numberPayload: number = action.payload
+  const stringPayload: string = action.payload
+}
+
+/*
+ * Test: PayloadAction has optional second type parameter for the type tag.
+ */
+{
+  const action: PayloadAction<number, string> = { type: '', payload: 5 }
+
+  // typings:expect-error
+  const action2: PayloadAction<number, string> = { type: 1, payload: 5 }
+
+  // typings:expect-error
+  const action3: PayloadAction<number, number> = { type: '', payload: 5 }
+}
+
+/* createAction() */
+
+/*
+ * Test: createAction() has type parameter for the action payload.
+ */
+{
+  const increment = createAction<number>('increment')
+  const incrementNumber: ActionCreator<PayloadAction<number>> = increment
+
+  // typings:expect-error
+  const incrementString: ActionCreator<PayloadAction<string>> = increment
+}
+
+/*
+ * Test: createAction() type parameter is optional (defaults to `any`).
+ */
+{
+  const increment = createAction('increment')
+  const incrementNumber: ActionCreator<PayloadAction<number>> = increment
+  const incrementString: ActionCreator<PayloadAction<string>> = increment
+}

--- a/typing-tests/typescript/createReducer.ts
+++ b/typing-tests/typescript/createReducer.ts
@@ -1,5 +1,4 @@
-import { createReducer, Reducer } from 'redux-starter-kit'
-import { bindActionCreators, AnyAction } from 'redux'
+import { AnyAction, createReducer, Reducer } from 'redux-starter-kit'
 
 /*
  * Test: createReducer() infers type of returned reducer.

--- a/typing-tests/typescript/createReducer.ts
+++ b/typing-tests/typescript/createReducer.ts
@@ -1,0 +1,59 @@
+import { createReducer, Reducer } from 'redux-starter-kit'
+import { bindActionCreators, AnyAction } from 'redux'
+
+/*
+ * Test: createReducer() infers type of returned reducer.
+ */
+{
+  type CounterAction =
+    | { type: 'increment'; payload: number }
+    | { type: 'decrement'; payload: number }
+
+  const incrementHandler = (state: number, action: CounterAction) => state + 1
+  const decrementHandler = (state: number, action: CounterAction) => state - 1
+
+  const reducer = createReducer(0, {
+    increment: incrementHandler,
+    decrement: decrementHandler
+  })
+
+  const numberReducer: Reducer<number, CounterAction> = reducer
+
+  // typings:expect-error
+  const stringReducer: Reducer<string, CounterAction> = reducer
+
+  // typings:expect-error
+  const anyActionReducer: Reducer<number, AnyAction> = reducer
+}
+
+/**
+ * Test: createReducer() type parameters can be specified expliclity.
+ */
+{
+  type CounterAction =
+    | { type: 'increment'; payload: number }
+    | { type: 'decrement'; payload: number }
+
+  const incrementHandler = (state: number, action: CounterAction) =>
+    state + action.payload
+
+  const decrementHandler = (state: number, action: CounterAction) =>
+    state - action.payload
+
+  createReducer<number, CounterAction>(0, {
+    increment: incrementHandler,
+    decrement: decrementHandler
+  })
+
+  // typings:expect-error
+  createReducer<string, CounterAction>(0, {
+    increment: incrementHandler,
+    decrement: decrementHandler
+  })
+
+  // typings:expect-error
+  createReducer<number, AnyAction>(0, {
+    increment: incrementHandler,
+    decrement: decrementHandler
+  })
+}

--- a/typing-tests/typescript/createSlice.ts
+++ b/typing-tests/typescript/createSlice.ts
@@ -1,0 +1,46 @@
+import {
+  AnyAction,
+  createSlice,
+  PayloadAction,
+  Reducer
+} from 'redux-starter-kit'
+
+/*
+ * Test: createSlice() infers the returned slice's type.
+ */
+{
+  const slice = createSlice({
+    slice: 'counter',
+    initialState: 0,
+    reducers: {
+      increment: (state: number, action: PayloadAction) =>
+        state + action.payload,
+      decrement: (state: number, action: PayloadAction) =>
+        state - action.payload
+    }
+  })
+
+  /* Reducer */
+
+  const reducer: Reducer<number, PayloadAction> = slice.reducer
+
+  // typings:expect-error
+  const stringReducer: Reducer<string, PayloadAction> = slice.reducer
+  // typings:expect-error
+  const anyActionReducer: Reducer<string, AnyAction> = slice.reducer
+
+  /* Actions */
+
+  slice.actions.increment(1)
+  slice.actions.decrement(1)
+
+  // typings:expect-error
+  slice.actions.other(1)
+
+  /* Selector */
+
+  const value: number = slice.selectors.getCounter(0)
+
+  // typings:expect-error
+  const stringValue: string = slice.selectors.getCounter(0)
+}

--- a/typing-tests/typescript/tsconfig.json
+++ b/typing-tests/typescript/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015"],
+    "strict": true,
+    "baseUrl": "../..",
+    "paths": {
+      "redux-starter-kit": ["index.d.ts"]
+    }
+  }
+}


### PR DESCRIPTION
This PR is a less ambitious alternative to #38. It is not a rewrite in TypeScript, but simply adds a separate type definition file (`index.d.ts`), similar to how TypeScript support is provided in the core Redux repo. Also like in the case of Redux, the typings come with a set of test TypeScript files run through [typings-tester](https://www.npmjs.com/package/typings-tester) to ensure that the typings work as intended.

I am sure that some of the typings could be made even more precise. I'd say, though, that this is a decent first step that we can iterate on later, and it should be definitely better for TypeScript users than not having typings at all.