### PR TITLE
Add ability for slices to listen to other actions

### DIFF
--- a/docs/api/configureStore.md
+++ b/docs/api/configureStore.md
@@ -7,8 +7,7 @@ hide_title: true
 
 # `configureStore`
 
-A friendlier abstraction over the standard Redux `createStore` function. 
-
+A friendlier abstraction over the standard Redux `createStore` function.
 
 ## Parameters
 
@@ -34,17 +33,16 @@ function configureStore({
 
 If this is a single function, it will be directly used as the root reducer for the store.
 
-If it is an object of slice reducers, like `{users : usersReducer, posts : postsReducer}`, 
+If it is an object of slice reducers, like `{users : usersReducer, posts : postsReducer}`,
 `configureStore` will automatically create the root reducer by passing this object to the
 [Redux `combineReducers` utility](https://redux.js.org/api/combinereducers).
-
 
 ### `middleware`
 
 An optional array of Redux middleware functions.
 
 If this option is provided, it should contain all the middleware functions you
-want added to the store.  `configureStore` will automatically pass those to `applyMiddleware`.
+want added to the store. `configureStore` will automatically pass those to `applyMiddleware`.
 
 If not provided, `configureStore` will call `getDefaultMiddleware` and use the
 array of middleware functions it returns.
@@ -52,17 +50,15 @@ array of middleware functions it returns.
 For more details on how the `middleware` parameter works and the list of middleware that are added by default, see the
 [`getDefaultMiddleware` docs page](./getDefaultMiddleware.md).
 
-
 ### `devTools`
 
-A boolean indicating whether  `configureStore` should automatically enable support for [the Redux DevTools browser extension](https://github.com/zalmoxisus/redux-devtools-extension).
+A boolean indicating whether `configureStore` should automatically enable support for [the Redux DevTools browser extension](https://github.com/zalmoxisus/redux-devtools-extension).
 
 Defaults to true.
 
-The Redux DevTools Extension recently added [support for showing action stack traces](https://github.com/zalmoxisus/redux-devtools-extension/blob/d4ef75691ad294646f74bca38b973b19850a37cf/docs/Features/Trace.md) that show exactly where each action was dispatched.  Capturing the traces can add a bit of overhead, so the DevTools Extension allows users to configure whether action stack traces are captured.
+The Redux DevTools Extension recently added [support for showing action stack traces](https://github.com/zalmoxisus/redux-devtools-extension/blob/d4ef75691ad294646f74bca38b973b19850a37cf/docs/Features/Trace.md) that show exactly where each action was dispatched. Capturing the traces can add a bit of overhead, so the DevTools Extension allows users to configure whether action stack traces are captured.
 
 If this parameter is true, then `configureStore` will enable capturing action stack traces in development mode only.
-
 
 ### `preloadedState`
 
@@ -70,11 +66,10 @@ An optional initial state value to be passed to the Redux `createStore` function
 
 ### `enhancers`
 
-An optional array of Redux store enhancers.  If included, these will be passed to [the Redux `compose` function](https://redux.js.org/api/compose), and the combined enhancer will be passed to `createStore`.
+An optional array of Redux store enhancers. If included, these will be passed to [the Redux `compose` function](https://redux.js.org/api/compose), and the combined enhancer will be passed to `createStore`.
 
 This should _not_ include `applyMiddleware()` or
 the Redux DevTools Extension `composeWithDevTools`, as those are already handled by `configureStore`.
-
 
 ## Usage
 
@@ -89,7 +84,7 @@ const store = configureStore({ reducer: rootReducer })
 // The store now has redux-thunk added and the Redux DevTools Extension is turned on
 ```
 
-###  Full Example
+### Full Example
 
 ```js
 import { configureStore, getDefaultMiddleware } from 'redux-starter-kit'

--- a/docs/api/createReducer.md
+++ b/docs/api/createReducer.md
@@ -35,7 +35,9 @@ const counterReducer = createReducer(0, {
 })
 ```
 
-If you created action creators using `createAction()`, you can use those directly as keys for the case reducers.
+Action creators that were generated using [`createAction`](./createAction.md) may be used directly as the keys here, using
+computed property syntax. (If you are using TypeScript, you may have to use `actionCreator.type` or `actionCreator.toString()`
+to force the TS compiler to accept the computed property.)
 
 ```js
 const increment = createAction('increment')
@@ -43,7 +45,7 @@ const decrement = createAction('decrement')
 
 const counterReducer = createReducer(0, {
   [increment]: (state, action) => state + action.payload,
-  [decrement]: (state, action) => state - action.payload
+  [decrement.type]: (state, action) => state - action.payload
 })
 ```
 

--- a/docs/api/createSlice.md
+++ b/docs/api/createSlice.md
@@ -72,7 +72,7 @@ If two fields from `reducers` and `extraReducers` happen to end up with the same
 the function from `reducers` will be used to handle that action type.
 
 Action creators that were generated using [`createAction`](./createAction.md) may be used directly as the keys here, using
-computed property syntax.  (If you are using TypeScript, you may have to use `actionCreator.type` or `actionCreator.toString()`
+computed property syntax. (If you are using TypeScript, you may have to use `actionCreator.type` or `actionCreator.toString()`
 to force the TS compiler to accept the computed property.)
 
 ## Return Value

--- a/docs/api/createSlice.md
+++ b/docs/api/createSlice.md
@@ -9,7 +9,106 @@ hide_title: true
 
 A function that accepts an initial state, an object full of reducer functions, and optionally a "slice name", and automatically generates action creators, action types, and selectors that correspond to the reducers and state.
 
-The reducers will be wrapped in the [`createReducer()` utility](createReducer.md), and so they can safely "mutate" the state they are given.
+## Parameters
+
+`createSlice` accepts a single configuration object parameter, with the following options:
+
+```ts
+function configureStore({
+    // An object of "case reducers". Key names will be used to generate actions.
+    reducers: Object<string, ReducerFunction>
+    // The initial state for the reducer
+    initialState: any,
+    // An optional name, used in action types and selectors
+    slice?: string,
+    // An additional object of "case reducers". Keys should be other action types.
+    extraReducers?: Object<string, ReducerFunction>
+})
+```
+
+### `reducers`
+
+An object containing Redux "case reducer" functions (functions intended to handle a specific action type, equivalent
+to a single case statement in a switch).
+
+The keys in the object will be used to generate string action type constants, and these will show up in the Redux
+DevTools Extension when they are dispatched. Also, if any other part of the application happens to dispatch an action
+with the exact same type string, the corresponding reducer will be run. Therefore, you should give the functions
+descriptive names.
+
+This object will be passed to [`createReducer`](./createReducer.md), so the reducers may safely "mutate" the
+state they are given.
+
+### `initialState`
+
+The initial state value for this slice of state.
+
+### `slice`
+
+An optional string name for this slice of state.
+
+The slice name is used in two ways.
+
+First, if provided, generated action type constants will use this as a prefix.
+
+Second, it affects the name and behavior of the generated selector. If provided, a selector named after the slice
+will be generated. This selector assume the slice data exists in an object, with the slice name as the key, and will
+return the value at that key name. If not provided, a selector named `getState` will be generated that just returns
+its argument.
+
+### `extraReducers`
+
+One of the key concepts of Redux is that each slice reducer "owns" its slice of state, and that many slice reducers
+can independently respond to the same action type. `extraReducers` allows `createSlice` to respond to other action types
+besides the types it has generated.
+
+Like `reducers`, `extraReducers` should be an object containing Redux case reducer functions. However, the keys should
+be other Redux string action type constants, and `createSlice` will _not_ auto-generate action types or action creators
+for reducers included in this parameter.
+
+As with `reducers`, these reducers will also be passed to `createReducer` and may "mutate" their state safely.
+
+If two fields from `reducers` and `extraReducers` happen to end up with the same action type string,
+the function from `reducers` will be used to handle that action type.
+
+Action creators that were generated using [`createAction`](./createAction.md) may be used directly as the keys here, using
+computed property syntax.  (If you are using TypeScript, you may have to use `actionCreator.type` or `actionCreator.toString()`
+to force the TS compiler to accept the computed property.)
+
+## Return Value
+
+`createSlice` will return an object that looks like:
+
+```ts
+{
+    slice : string,
+    reducer : ReducerFunction,
+    actions : Object<string, ActionCreator},
+    selectors : Object<string, Selector>
+}
+```
+
+Each function defined in the `reducers` argument will have a corresponding action creator generated using [`createAction`](./createAction.md)
+and included in the result's `actions` field using the same function name.
+
+The generated `reducer` function is suitable for passing to the Redux `combineReducers` function as a "slice reducer".
+
+The generated selector function will be available in the result's `selectors` field.
+
+You may want to consider destructuring the action creators and exporting them individually, for ease of searching
+for references in a larger codebase.
+
+> **Note**: the result object is conceptually similar to a
+> ["Redux duck" code structure](https://redux.js.org/faq/code-structure#what-should-my-file-structure-look-like-how-should-i-group-my-action-creators-and-reducers-in-my-project-where-should-my-selectors-go).
+> The actual code structure you use is up to you, but there are a couple caveats to keep in mind:
+>
+> - Actions are not exclusively limited to a single slice. Any part of the reducer logic can (and should!) respond
+>   to any dispatched action.
+> - At the same time, circular references can cause import problems. If slices A and B are defined in
+>   separate files, and each file tries to import the other so it can listen to other actions, unexpected
+>   behavior may occur.
+
+## Examples
 
 ```js
 import { createSlice } from 'redux-starter-kit'
@@ -27,10 +126,15 @@ const counter = createSlice({
 
 const user = createSlice({
   slice: 'user',
-  initialState: { name: '' },
+  initialState: { name: '', age: 20 },
   reducers: {
     setUserName: (state, action) => {
       state.name = action.payload // mutate the state all you want with immer
+    }
+  },
+  extraReducers: {
+    [counter.actions.increment]: (state, action) => {
+      state.age += 1
     }
   }
 })
@@ -43,18 +147,18 @@ const reducer = combineReducers({
 const store = createStore(reducer)
 
 store.dispatch(counter.actions.increment())
-// -> { counter: 1, user: {} }
+// -> { counter: 1, user: {name : '', age: 20} }
 store.dispatch(counter.actions.increment())
-// -> { counter: 2, user: {} }
+// -> { counter: 2, user: {name: '', age: 22} }
 store.dispatch(counter.actions.multiply(3))
-// -> { counter: 6, user: {} }
+// -> { counter: 6, user: {name: '', age: 22} }
 console.log(`${counter.actions.decrement}`)
-// -> counter/decrement
+// -> "counter/decrement"
 store.dispatch(user.actions.setUserName('eric'))
-// -> { counter: 6, user: { name: 'eric' } }
+// -> { counter: 6, user: { name: 'eric', age: 22} }
 const state = store.getState()
 console.log(user.selectors.getUser(state))
-// -> { name: 'eric' }
+// -> { name: 'eric', age: 22 }
 console.log(counter.selectors.getCounter(state))
 // -> 6
 ```

--- a/docs/api/createSlice.md
+++ b/docs/api/createSlice.md
@@ -149,7 +149,7 @@ const store = createStore(reducer)
 store.dispatch(counter.actions.increment())
 // -> { counter: 1, user: {name : '', age: 20} }
 store.dispatch(counter.actions.increment())
-// -> { counter: 2, user: {name: '', age: 22} }
+// -> { counter: 2, user: {name: '', age: 21} }
 store.dispatch(counter.actions.multiply(3))
 // -> { counter: 6, user: {name: '', age: 22} }
 console.log(`${counter.actions.decrement}`)

--- a/docs/api/getDefaultMiddleware.md
+++ b/docs/api/getDefaultMiddleware.md
@@ -15,7 +15,7 @@ By default, [`configureStore`](./configureStore.md) adds some middleware to the 
 
 ```js
 const store = configureStore({
-    reducer : rootReducer,
+  reducer: rootReducer
 })
 
 // Store has one or more middleware added, because the middleware list was not customized
@@ -25,8 +25,8 @@ If you want to customize the list of middleware, you can supply an array of midd
 
 ```js
 const store = configureStore({
-    reducer : rootReducer,
-    middleware : [thunk, logger],
+  reducer: rootReducer,
+  middleware: [thunk, logger]
 })
 
 // Store specifically has the thunk and logger middleware applied
@@ -40,30 +40,29 @@ middleware added as well:
 
 ```js
 const store = configureStore({
-    reducer : rootReducer,
-    middleware: [...getDefaultMiddleware(), logger]
+  reducer: rootReducer,
+  middleware: [...getDefaultMiddleware(), logger]
 })
 
 // Store has all of the default middleware added, _plus_ the logger middleware
 ```
 
-
 ## Included Default Middleware
 
 ### Development
 
-One of the goals of `redux-starter-kit` is to provide opinionated defaults and prevent common mistakes.  As part of that,
-`getDefaultMiddleware` includes some middleware that are added **in development builds of your app only** to 
+One of the goals of `redux-starter-kit` is to provide opinionated defaults and prevent common mistakes. As part of that,
+`getDefaultMiddleware` includes some middleware that are added **in development builds of your app only** to
 provide runtime checks for two common issues:
 
-- [`redux-immutable-state-invariant`](https://github.com/leoasis/redux-immutable-state-invariant): deeply compares 
-state values for mutations.  It can detect mutations in reducers during a dispatch, and also mutations that occur between
-dispatches (such as in a component or a selector).  When a mutation is detect, it will throw an error and indicate the key
-path for where the mutated value was detected in the state tree.
-- `serializable-state-invariant-middleware`: a custom middleware created specifically for use in `redux-starter-kit`.  Similar in
-concept to `redux-immutable-state-invariant`, but deeply checks your state tree and your actions for non-serializable values
-such as functions, Promises, Symbols, and other non-plain-JS-data values.  When a non-serializable value is detected, a
-console error will be printed with the key path for where the non-serializable value was detected.
+- [`redux-immutable-state-invariant`](https://github.com/leoasis/redux-immutable-state-invariant): deeply compares
+  state values for mutations. It can detect mutations in reducers during a dispatch, and also mutations that occur between
+  dispatches (such as in a component or a selector). When a mutation is detect, it will throw an error and indicate the key
+  path for where the mutated value was detected in the state tree.
+- `serializable-state-invariant-middleware`: a custom middleware created specifically for use in `redux-starter-kit`. Similar in
+  concept to `redux-immutable-state-invariant`, but deeply checks your state tree and your actions for non-serializable values
+  such as functions, Promises, Symbols, and other non-plain-JS-data values. When a non-serializable value is detected, a
+  console error will be printed with the key path for where the non-serializable value was detected.
 
 In addition to these development tool middleware, it also adds [`redux-thunk`](https://github.com/reduxjs/redux-thunk)
 by default, since thunks are the basic recommended side effects middleware for Redux.
@@ -71,7 +70,7 @@ by default, since thunks are the basic recommended side effects middleware for R
 Currently, the return value is:
 
 ```js
-[immutableStateInvariant, thunk, serializableStateInvariant]
+;[immutableStateInvariant, thunk, serializableStateInvariant]
 ```
 
 ### Production
@@ -79,5 +78,5 @@ Currently, the return value is:
 Currently, the return value is:
 
 ```js
-[thunk]
+;[thunk]
 ```

--- a/docs/api/otherExports.md
+++ b/docs/api/otherExports.md
@@ -9,31 +9,32 @@ hide_title: true
 
 `redux-starter-kit` exports some of its internal utilities, and re-exports additional functions from other dependencies as well.
 
-
 ## Internal Exports
-
 
 ### `createSerializableStateInvariantMiddleware`
 
 Creates an instance of the `serializable-state-invariant` middleware described in [`getDefaultMiddleware`](./getDefaultMiddleware.md).
 
 Accepts an options object with an `isSerializable` parameter, which will be used
-to determine if a value is considered serializable or not.  If not provided, this
+to determine if a value is considered serializable or not. If not provided, this
 defaults to `isPlain`.
 
 Example:
 
 ```js
-import {configureStore, createSerializableStateInvariantMiddleware} from "redux-starter-kit";
+import {
+  configureStore,
+  createSerializableStateInvariantMiddleware
+} from 'redux-starter-kit'
 
 const serializableMiddleware = createSerializableStateInvariantMiddleware({
-    isSerializable: () => true // all values will be accepted
-});
+  isSerializable: () => true // all values will be accepted
+})
 
 const store = configureStore({
-    reducer,
-    middleware : [serializableMiddleware],
-});
+  reducer,
+  middleware: [serializableMiddleware]
+})
 ```
 
 ### `isPlain`
@@ -55,7 +56,6 @@ function isPlain(val) {
   )
 }
 ```
-
 
 ## Exports from Other Libraries
 

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -18,7 +18,7 @@ export interface PayloadAction<P = any, T extends string = string>
 export interface PayloadActionCreator<P = any, T extends string = string> {
   (): Action<T>
   (payload: P): PayloadAction<P, T>
-  type: string
+  type: T
 }
 
 /**
@@ -32,14 +32,14 @@ export interface PayloadActionCreator<P = any, T extends string = string> {
  */
 export function createAction<P = any, T extends string = string>(
   type: T
-): PayloadActionCreator<P> {
+): PayloadActionCreator<P, T> {
   function actionCreator(): Action<T>
   function actionCreator(payload: P): PayloadAction<P, T>
   function actionCreator(payload?: P): Action<T> | PayloadAction<P, T> {
     return { type, payload }
   }
 
-  actionCreator.toString = () => `${type}`
+  actionCreator.toString = (): T => `${type}` as T
 
   actionCreator.type = type
 

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -18,6 +18,7 @@ export interface PayloadAction<P = any, T extends string = string>
 export interface PayloadActionCreator<P = any, T extends string = string> {
   (): Action<T>
   (payload: P): PayloadAction<P, T>
+  type : string
 }
 
 /**
@@ -39,6 +40,8 @@ export function createAction<P = any, T extends string = string>(
   }
 
   actionCreator.toString = () => `${type}`
+
+  actionCreator.type = type
 
   return actionCreator
 }

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -18,7 +18,7 @@ export interface PayloadAction<P = any, T extends string = string>
 export interface PayloadActionCreator<P = any, T extends string = string> {
   (): Action<T>
   (payload: P): PayloadAction<P, T>
-  type : string
+  type: string
 }
 
 /**

--- a/src/createSlice.test.ts
+++ b/src/createSlice.test.ts
@@ -1,4 +1,5 @@
 import { createSlice } from './createSlice'
+import { createAction } from './createAction'
 
 describe('createSlice', () => {
   describe('when slice is empty', () => {
@@ -103,6 +104,27 @@ describe('createSlice', () => {
       expect(reducer(initialState, actions.setUserName('eric'))).toEqual({
         user: 'eric'
       })
+    })
+  })
+
+  describe('when passing extra reducers', () => {
+    const addMore = createAction('ADD_MORE')
+
+    const { reducer } = createSlice({
+      reducers: {
+        increment: state => state + 1,
+        multiply: (state, action) => state * action.payload
+      },
+      extraReducers: {
+        [addMore.type]: (state, action) => state + action.payload.amount
+      },
+      initialState: 0
+    })
+
+    it('should call extra reducers when their actions are dispatched', () => {
+      const result = reducer(10, addMore({ amount: 5 }))
+
+      expect(result).toBe(15)
     })
   })
 })

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -39,7 +39,8 @@ export interface Slice<
 export interface CreateSliceOptions<
   S = any,
   A extends Action = AnyAction,
-  CR extends CaseReducersMapObject<S, A> = CaseReducersMapObject<S, A>
+  CR extends CaseReducersMapObject<S, A> = CaseReducersMapObject<S, A>,
+  CR2 extends CaseReducersMapObject<S, A> = CaseReducersMapObject<S, A>
 > {
   /**
    * The slice's name. Used to namespace the generated action types and to
@@ -58,6 +59,13 @@ export interface CreateSliceOptions<
    * generated using `createAction()`.
    */
   reducers: CR
+
+  /**
+   * A mapping from action types to action-type-specific *case reducer*
+   * functions. These reducers should have existing action types used
+   * as the keys, and action creators will _not_ be generated.
+   */
+  extraReducers?: CR2
 }
 
 function getType(slice: string, actionKey: string): string {
@@ -81,15 +89,13 @@ export function createSlice<
 ): Slice<S, A, Extract<keyof CR, string>> {
   const { slice = '', initialState } = options
   const reducers = options.reducers || {}
+  const extraReducers = options.extraReducers || {}
   const actionKeys = Object.keys(reducers)
 
-  const reducerMap = actionKeys.reduce(
-    (map, actionKey) => {
-      map[getType(slice, actionKey)] = reducers[actionKey]
-      return map
-    },
-    {} as CR
-  )
+  const reducerMap = actionKeys.reduce((map, actionKey) => {
+    map[getType(slice, actionKey)] = reducers[actionKey]
+    return map
+  }, extraReducers)
 
   const reducer = createReducer(initialState, reducerMap)
 

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -54,10 +54,10 @@ import {
  * on whether a payload is passed.
  */
 {
-  const actionCreator: PayloadActionCreator = (payload?: number) => ({
+  const actionCreator: PayloadActionCreator = Object.assign((payload?: number) => ({
     type: 'action',
     payload
-  })
+  }), {type : 'action'})
 
   let action: Action
   let payloadAction: PayloadAction
@@ -74,18 +74,20 @@ import {
  * Test: PayloadActionCreator is compatible with ActionCreator.
  */
 {
-  const payloadActionCreator: PayloadActionCreator = (payload?: number) => ({
+  const payloadActionCreator: PayloadActionCreator = Object.assign((payload?: number) => ({
     type: 'action',
     payload
-  })
+  }), {type : 'action'})
   const actionCreator: ActionCreator<AnyAction> = payloadActionCreator
 
-  const payloadActionCreator2: PayloadActionCreator<number> = (
+  const payloadActionCreator2: PayloadActionCreator<number> = Object.assign((
     payload?: number
   ) => ({
     type: 'action',
     payload: payload || 1
-  })
+  }), {type : 'action'})
+
+
   const actionCreator2: ActionCreator<
     PayloadAction<number>
   > = payloadActionCreator2

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -54,10 +54,13 @@ import {
  * on whether a payload is passed.
  */
 {
-  const actionCreator: PayloadActionCreator = Object.assign((payload?: number) => ({
-    type: 'action',
-    payload
-  }), {type : 'action'})
+  const actionCreator: PayloadActionCreator = Object.assign(
+    (payload?: number) => ({
+      type: 'action',
+      payload
+    }),
+    { type: 'action' }
+  )
 
   let action: Action
   let payloadAction: PayloadAction
@@ -74,19 +77,22 @@ import {
  * Test: PayloadActionCreator is compatible with ActionCreator.
  */
 {
-  const payloadActionCreator: PayloadActionCreator = Object.assign((payload?: number) => ({
-    type: 'action',
-    payload
-  }), {type : 'action'})
+  const payloadActionCreator: PayloadActionCreator = Object.assign(
+    (payload?: number) => ({
+      type: 'action',
+      payload
+    }),
+    { type: 'action' }
+  )
   const actionCreator: ActionCreator<AnyAction> = payloadActionCreator
 
-  const payloadActionCreator2: PayloadActionCreator<number> = Object.assign((
-    payload?: number
-  ) => ({
-    type: 'action',
-    payload: payload || 1
-  }), {type : 'action'})
-
+  const payloadActionCreator2: PayloadActionCreator<number> = Object.assign(
+    (payload?: number) => ({
+      type: 'action',
+      payload: payload || 1
+    }),
+    { type: 'action' }
+  )
 
   const actionCreator2: ActionCreator<
     PayloadAction<number>
@@ -99,7 +105,7 @@ import {
  * Test: createAction() has type parameter for the action payload.
  */
 {
-  const increment = createAction<number>('increment')
+  const increment = createAction<number, 'increment'>('increment')
   const n: number = increment(1).payload
 
   // typings:expect-error
@@ -113,4 +119,17 @@ import {
   const increment = createAction('increment')
   const n: number = increment(1).payload
   const s: string = increment(1).payload
+}
+/*
+ * Test: createAction().type is a string literal.
+ */
+{
+  const increment = createAction('increment')
+  const n: string = increment(1).type
+  const s: 'increment' = increment(1).type
+
+  // typings:expect-error
+  const r: 'other' = increment(1).type
+  // typings:expect-error
+  const q: number = increment(1).type
 }

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -2,13 +2,16 @@ import {
   AnyAction,
   createSlice,
   PayloadAction,
-  Reducer
+  Reducer,
+  createAction
 } from 'redux-starter-kit'
 
 /*
  * Test: createSlice() infers the returned slice's type.
  */
 {
+  const firstAction = createAction<{ count: number }>('FIRST_ACTION')
+
   const slice = createSlice({
     slice: 'counter',
     initialState: 0,
@@ -17,7 +20,8 @@ import {
       decrement: (state: number, action) => state - action.payload
     },
     extraReducers: {
-      "OTHER_ACTION_TYPE" : (state : number, action ) => state + action.payload.count
+      [firstAction.type]: (state: number, action) =>
+        state + action.payload.count
     }
   })
 

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -15,6 +15,9 @@ import {
     reducers: {
       increment: (state: number, action) => state + action.payload,
       decrement: (state: number, action) => state - action.payload
+    },
+    extraReducers: {
+      "OTHER_ACTION_TYPE" : (state : number, action ) => state + action.payload.count
     }
   })
 


### PR DESCRIPTION
Thus far, slices generated by `createSlice` could only listen to the specific action types defined for each field in the `reducers` option.

I've added a field named `extraReducers` that lets you add reducers that listen to action types that were defined elsewhere.

I'm open to bikeshedding suggestions on the field name.  Other ideas:

```
otherReducers
listenForActions
handleActions
```

I also updated `createAction` so that action creators have the string available as a `type` field. This was requested in #72 for use with switch statements.  Turns out it also helps with TS usage, because TS won't let you pass a function directly as a computed object property - it's not a string or `any`.  So, `[actionCreator.type]` is a passable alternative.

The TS compiler _seems_ to be okay with this at the moment, but this is the first time I've ever done anything meaningful with TS, so I'd appreciate review.  (Paging @denisw , @Dudeonyx , and @jessidhia ...) 

I filled out the `createSlice` docs as well.