### PR TITLE
Re-export compose and combineReducers from redux for convenience

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,9 @@ export {
   Middleware,
   Reducer,
   Store,
-  StoreEnhancer
+  StoreEnhancer,
+  combineReducers,
+  compose
 } from 'redux'
 export { default as createSelector } from 'selectorator'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { combineReducers, compose } from 'redux'
 export { default as createNextState } from 'immer'
 export { default as createSelector } from 'selectorator'
 


### PR DESCRIPTION
Just to mach what's in the [docs](https://redux-starter-kit.js.org/api/other-exports) and for convenience this PR re-exports `compose` and `combineReducers` from the original `redux` package.