### PR TITLE
Type payload-less slice action creators to take no arguments

### DIFF
--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -6,11 +6,12 @@ import { createSliceSelector, createSelectorName } from './sliceSelector'
 /**
  * An action creator atttached to a slice.
  */
-export type SliceActionCreator<P> = (payload: P) => PayloadAction<P>
+export type SliceActionCreator<P, T extends string = string> = P extends void
+  ? () => Action<T>
+  : (payload: P) => PayloadAction<P, T>
 
 export interface Slice<
   S = any,
-  A extends Action = AnyAction,
   AP extends { [key: string]: any } = { [key: string]: any }
 > {
   /**
@@ -21,13 +22,15 @@ export interface Slice<
   /**
    * The slice's reducer.
    */
-  reducer: Reducer<S, A>
+  reducer: Reducer<S>
 
   /**
    * Action creators for the types of actions that are handled by the slice
    * reducer.
    */
-  actions: { [type in keyof AP]: SliceActionCreator<AP[type]> }
+  actions: {
+    [type in keyof AP]: SliceActionCreator<AP[type], Extract<type, string>>
+  }
 
   /**
    * Selectors for the slice reducer state. `createSlice()` inserts a single
@@ -101,9 +104,7 @@ export function createSlice<
   S = any,
   A extends PayloadAction = PayloadAction<any>,
   CR extends CaseReducersMapObject<S, A> = CaseReducersMapObject<S, A>
->(
-  options: CreateSliceOptions<S, A, CR>
-): Slice<S, A, ExtractPayloads<S, A, CR>> {
+>(options: CreateSliceOptions<S, A, CR>): Slice<S, ExtractPayloads<S, A, CR>> {
   const { slice = '', initialState } = options
   const reducers = options.reducers || {}
   const extraReducers = options.extraReducers || {}

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -1,4 +1,5 @@
 import {
+  Action,
   AnyAction,
   createSlice,
   PayloadAction,
@@ -63,6 +64,10 @@ import {
       multiply: (state, action: PayloadAction<number>) => state * action.payload
     }
   })
+
+  const increment: () => Action<'increment'> = counter.actions.increment
+  const multiply: (payload: number) => PayloadAction<number, 'multiply'> =
+    counter.actions.multiply
 
   counter.actions.increment()
   counter.actions.multiply(2)


### PR DESCRIPTION
Previously, it was not possible to assign a slice action creator without payload to `() => any` because the type was inferred as `(payload: void) => any`. Now we use a conditional type for `SliceActionCreator` that special-cases `void`.

Fixes #108.