### PR TITLE
Fix link to api breaking

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -35,7 +35,7 @@ class Footer extends React.Component {
           <div>
             <h5>Docs</h5>
             <a href={this.docUrl('introduction/quick-start')}>Quick Start</a>
-            <a href={this.docUrl('api')}>API Reference</a>
+            <a href={this.docUrl('api/configureStore')}>API Reference</a>
           </div>
           <div>
             <h5>Community</h5>


### PR DESCRIPTION
Apparently, this footer link [API Reference](https://redux-starter-kit.js.org/api) breaks, whereas this works [API Reference](https://redux-starter-kit.js.org/api/configurestore)