### PR TITLE
Improve type inference of case reducers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: 'react-app',
-  parser: 'typescript-eslint-parser',
+  parser: '@typescript-eslint/parser',
 
   rules: {
     'jsx-a11y/href-no-hash': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -975,6 +975,47 @@
         "redux": "^3.6.0 || ^4.0.0"
       }
     },
+    "@typescript-eslint/parser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.6.0.tgz",
+      "integrity": "sha512-VB9xmSbfafI+/kI4gUK3PfrkGmrJQfh0N4EScT1gZXSZyUxpsBirPL99EWZg9MmPG0pzq/gMtgkk7/rAHj4aQw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "1.6.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.6.0.tgz",
+      "integrity": "sha512-A4CanUwfaG4oXobD5y7EXbsOHjCwn8tj1RDd820etpPAjH+Icjc2K9e/DQM1Hac5zH2BSy+u6bjvvF2wwREvYA==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
+    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -7582,50 +7623,10 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
+      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
       "dev": true
-    },
-    "typescript-eslint-parser": {
-      "version": "github:eslint/typescript-eslint-parser#a8fee9089306b9fc890dd9275cbc7f3988fcccda",
-      "from": "github:eslint/typescript-eslint-parser",
-      "dev": true,
-      "requires": {
-        "eslint-scope": "^4.0.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "typescript-estree": "18.0.0"
-      },
-      "dependencies": {
-        "eslint-scope": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-          "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        }
-      }
-    },
-    "typescript-estree": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/typescript-estree/-/typescript-estree-18.0.0.tgz",
-      "integrity": "sha512-HxTWrzFyYOPWA91Ij7xL9mNUVpGTKLH2KiaBn28CMbYgX2zgWdJqU9hO7Are+pAPAqY91NxAYoaAyDDZ3rLj2A==",
-      "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-          "dev": true
-        }
-      }
     },
     "typings-tester": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/jest": "^23.3.12",
     "@types/node": "^10.12.18",
     "@types/redux-immutable-state-invariant": "^2.1.0",
+    "@typescript-eslint/parser": "^1.6.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "eslint": "^4.17.0",
@@ -29,8 +30,7 @@
     "rollup-plugin-babel": "^4.2.0",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-resolve": "^4.0.0",
-    "typescript": "^3.2.2",
-    "typescript-eslint-parser": "eslint/typescript-eslint-parser",
+    "typescript": "^3.4.3",
     "typings-tester": "^0.3.2"
   },
   "scripts": {

--- a/src/createSlice.test.ts
+++ b/src/createSlice.test.ts
@@ -1,12 +1,13 @@
 import { createSlice } from './createSlice'
-import { createAction } from './createAction'
+import { createAction, PayloadAction } from './createAction'
 
 describe('createSlice', () => {
   describe('when slice is empty', () => {
     const { actions, reducer, selectors } = createSlice({
       reducers: {
         increment: state => state + 1,
-        multiply: (state, action) => state * action.payload
+        multiply: (state, action: PayloadAction<number>) =>
+          state * action.payload
       },
       initialState: 0
     })

--- a/type-tests/files/createReducer.typetest.ts
+++ b/type-tests/files/createReducer.typetest.ts
@@ -23,7 +23,7 @@ import { AnyAction, createReducer, Reducer } from 'redux-starter-kit'
 }
 
 /**
- * Test: createReducer() type parameters can be specified expliclity.
+ * Test: createReducer() state type can be specified expliclity.
  */
 {
   type CounterAction =
@@ -36,19 +36,13 @@ import { AnyAction, createReducer, Reducer } from 'redux-starter-kit'
   const decrementHandler = (state: number, action: CounterAction) =>
     state - action.payload
 
-  createReducer<number, CounterAction>(0, {
+  createReducer<number>(0, {
     increment: incrementHandler,
     decrement: decrementHandler
   })
 
   // typings:expect-error
-  createReducer<string, CounterAction>(0, {
-    increment: incrementHandler,
-    decrement: decrementHandler
-  })
-
-  // typings:expect-error
-  createReducer<number, AnyAction>(0, {
+  createReducer<string>(0, {
     increment: incrementHandler,
     decrement: decrementHandler
   })


### PR DESCRIPTION
Previously, the TypeScript compiler would reject case reducer maps (such as the ones passed to `createReducers` and `createSlice`) with different incompatible `PayloadAction` types. I restructured the types a bit to improve type inference in these cases.

Fixes #131