### PR TITLE
Fix PayloadAction inference

### DIFF
--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -5,6 +5,10 @@ import { createSliceSelector, createSelectorName } from './sliceSelector'
 
 /**
  * An action creator atttached to a slice.
+ *
+ * The `P` generic is wrapped with a single-element tuple to prevent the
+ * conditional from being checked distributively, thus preserving unions
+ * of contra-variant types.
  */
 export type SliceActionCreator<P> = [P] extends [void]
   ? () => PayloadAction<void>

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -6,7 +6,7 @@ import { createSliceSelector, createSelectorName } from './sliceSelector'
 /**
  * An action creator atttached to a slice.
  */
-export type SliceActionCreator<P> = P extends void
+export type SliceActionCreator<P> = [P] extends [void]
   ? () => PayloadAction<void>
   : (payload: P) => PayloadAction<P>
 

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -60,12 +60,16 @@ import {
     reducers: {
       increment: state => state + 1,
       decrement: state => state - 1,
-      multiply: (state, action: PayloadAction<number>) => state * action.payload
+      multiply: (state, { payload }: PayloadAction<number | number[]>) =>
+        Array.isArray(payload)
+          ? payload.reduce((acc, val) => acc * val, state)
+          : state * payload
     }
   })
 
   counter.actions.increment()
   counter.actions.multiply(2)
+  counter.actions.multiply([2, 3, 4])
 
   // typings:expect-error
   counter.actions.multiply()


### PR DESCRIPTION
By wrapping the `P` match in `SliceActionCreator<P>` with a single-element tuple, it prevents the conditional from being checked distributively, which otherwise has the effect of converting a union into an intersection when used with contra-variant types.

Without this change, the modified test emits the following error:

`Argument of type '2' is not assignable to parameter of type 'number & number[]'.
      Type '2' is not assignable to type 'number[]'.`

 `Argument of type 'number[]' is not assignable to parameter of type 'number & number[]'.
      Type 'number[]' is not assignable to type 'number'.`

My original two comments on this issue are here: https://github.com/reduxjs/redux-starter-kit/pull/133#issuecomment-484819765 and here: https://github.com/reduxjs/redux-starter-kit/pull/133#issuecomment-485247351. More information about distributive conditionals can be found here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html. They're very useful and typically match our intent when combining unions with other types, but in cases like these they end up transforming the resulting type into something entirely useless.