### PR TITLE
Fix: SerializableStateInvariantMiddleware: Use `isSerializable` when checking state

### DIFF
--- a/src/serializableStateInvariantMiddleware.test.ts
+++ b/src/serializableStateInvariantMiddleware.test.ts
@@ -158,4 +158,43 @@ describe('serializableStateInvariantMiddleware', () => {
     expect(value).toBe(badValue)
     expect(actionType).toBe(ACTION_TYPE)
   })
+
+  it('Should use the supplied isSerializable function to determine serializability', () => {
+    const ACTION_TYPE = 'TEST_ACTION'
+
+    const initialState = {
+      a: 0
+    }
+
+    const badValue = new Map()
+
+    const reducer: Reducer = (state = initialState, action) => {
+      switch (action.type) {
+        case ACTION_TYPE: {
+          return {
+            a: badValue
+          }
+        }
+        default:
+          return state
+      }
+    }
+
+    const serializableStateInvariantMiddleware = createSerializableStateInvariantMiddleware({
+      isSerializable: (value: any) => true
+    })
+
+    const store = configureStore({
+      reducer: {
+        testSlice: reducer
+      },
+      middleware: [serializableStateInvariantMiddleware]
+    })
+
+    store.dispatch({ type: ACTION_TYPE })
+
+    // Supplied 'isSerializable' considers all values serializable, hence
+    // no error logging is expected:
+    expect(console.error).not.toHaveBeenCalled()
+  })
 })

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -123,7 +123,11 @@ export function createSerializableStateInvariantMiddleware(
 
     const state = storeAPI.getState()
 
-    const foundStateNonSerializableValue = findNonSerializableValue(state)
+    const foundStateNonSerializableValue = findNonSerializableValue(
+      state,
+      [],
+      isSerializable
+    )
 
     if (foundStateNonSerializableValue) {
       const { keyPath, value } = foundStateNonSerializableValue


### PR DESCRIPTION
SerializableStateInvariantMiddleware: Actually use the supplied
`isSerializable` function when searching for non-serialisable values
in the state.