### PR TITLE
Allow consumer to augment middleware to tolerate certain structures (e.g. Immutable)

### DIFF
--- a/docs/api/otherExports.md
+++ b/docs/api/otherExports.md
@@ -20,6 +20,7 @@ Accepts an options object with `isSerializable` and `getEntries` parameters.  Th
 Example:
 
 ```js
+import { Iterable } from 'immutable';
 import {
   configureStore,
   createSerializableStateInvariantMiddleware,

--- a/docs/api/otherExports.md
+++ b/docs/api/otherExports.md
@@ -15,20 +15,27 @@ Redux Starter Kit exports some of its internal utilities, and re-exports additio
 
 Creates an instance of the `serializable-state-invariant` middleware described in [`getDefaultMiddleware`](./getDefaultMiddleware.md).
 
-Accepts an options object with an `isSerializable` parameter, which will be used
-to determine if a value is considered serializable or not. If not provided, this
-defaults to `isPlain`.
+Accepts an options object with `isSerializable` and `getEntries` parameters.  The former, `isSerializable`, will be used to determine if a value is considered serializable or not. If not provided, this defaults to `isPlain`.  The latter, `getEntries`, will be used to retrieve nested values.  If not provided, `Object.entries` will be used by default.
 
 Example:
 
 ```js
 import {
   configureStore,
-  createSerializableStateInvariantMiddleware
+  createSerializableStateInvariantMiddleware,
+  isPlain
 } from 'redux-starter-kit'
 
+// Augment middleware to consider Immutable.JS iterables serializable
+const isSerializable = (value) =>
+  Iterable.isIterable(value) || isPlain(value)
+
+const getEntries = (value) =>
+  Iterable.isIterable(value) ? value.entries() : Object.entries(value)
+
 const serializableMiddleware = createSerializableStateInvariantMiddleware({
-  isSerializable: () => true // all values will be accepted
+  isSerializable,
+  getEntries,
 })
 
 const store = configureStore({

--- a/src/serializableStateInvariantMiddleware.test.ts
+++ b/src/serializableStateInvariantMiddleware.test.ts
@@ -3,7 +3,8 @@ import { configureStore } from './configureStore'
 
 import {
   createSerializableStateInvariantMiddleware,
-  findNonSerializableValue
+  findNonSerializableValue,
+  isPlain,
 } from './serializableStateInvariantMiddleware'
 
 describe('findNonSerializableValue', () => {
@@ -158,4 +159,125 @@ describe('serializableStateInvariantMiddleware', () => {
     expect(value).toBe(badValue)
     expect(actionType).toBe(ACTION_TYPE)
   })
+
+  describe('consumer tolerated structures', () => {
+    const nonSerializableValue = new Map();
+    
+    const nestedSerializableObjectWithBadValue = {
+      isSerializable: true, 
+      entries: (): [string, any][] =>
+        [
+          ['good-string', 'Good!'],
+          ['good-number', 1337],
+          ['bad-map-instance', nonSerializableValue],
+        ],
+    };
+  
+    const serializableObject = { 
+      isSerializable: true, 
+      entries: (): [string, any][] => 
+        [
+          ['first', 1], 
+          ['second', 'B!'], 
+          ['third', nestedSerializableObjectWithBadValue]
+        ],
+    };
+
+    it('Should log an error when a non-serializable value is nested in state', () => {
+      const ACTION_TYPE = 'TEST_ACTION'
+  
+      const initialState = {
+        a: 0
+      }
+  
+      const reducer: Reducer = (state = initialState, action) => {
+        switch (action.type) {
+          case ACTION_TYPE: {
+            return {
+              a: serializableObject
+            }
+          }
+          default:
+            return state
+        }
+      }
+  
+      // use default options
+      const serializableStateInvariantMiddleware = createSerializableStateInvariantMiddleware()
+  
+      const store = configureStore({
+        reducer: {
+          testSlice: reducer
+        },
+        middleware: [serializableStateInvariantMiddleware]
+      })
+  
+      store.dispatch({ type: ACTION_TYPE })
+  
+  
+      expect(console.error).toHaveBeenCalled()
+  
+      const [
+        message,
+        keyPath,
+        value,
+        actionType
+      ] = (console.error as jest.Mock).mock.calls[0]
+  
+      // since default options are used, the `entries` function in `serializableObject` will cause the error
+      expect(message).toContain('detected in the state, in the path: `%s`')
+      expect(keyPath).toBe('testSlice.a.entries')
+      expect(value).toBe(serializableObject.entries)
+      expect(actionType).toBe(ACTION_TYPE)  
+    })
+
+    it('Should use consumer supplied isSerializable and getEntries options to tolerate certain structures', () => {
+      const ACTION_TYPE = 'TEST_ACTION'
+    
+      const initialState = {
+        a: 0
+      }
+    
+      const isSerializable = (val: any): boolean => val.isSerializable || isPlain(val);
+      const getEntries = (val: any): [string, any][] => val.isSerializable ? val.entries() : Object.entries(val);
+    
+      const reducer: Reducer = (state = initialState, action) => {
+        switch (action.type) {
+          case ACTION_TYPE: {
+            return {
+              a: serializableObject
+            }
+          }
+          default:
+            return state
+        }
+      }
+    
+      const serializableStateInvariantMiddleware = createSerializableStateInvariantMiddleware({ isSerializable, getEntries })
+    
+      const store = configureStore({
+        reducer: {
+          testSlice: reducer
+        },
+        middleware: [serializableStateInvariantMiddleware]
+      })
+    
+      store.dispatch({ type: ACTION_TYPE })
+        
+      expect(console.error).toHaveBeenCalled()
+    
+      const [
+        message,
+        keyPath,
+        value,
+        actionType
+      ] = (console.error as jest.Mock).mock.calls[0]
+    
+      // error reported is from a nested class instance, rather than the `entries` function `serializableObject`
+      expect(message).toContain('detected in the state, in the path: `%s`')
+      expect(keyPath).toBe('testSlice.a.third.bad-map-instance')
+      expect(value).toBe(nonSerializableValue)
+      expect(actionType).toBe(ACTION_TYPE)  
+    })  
+  });
 })

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -40,7 +40,8 @@ interface NonSerializableValue {
 export function findNonSerializableValue(
   value: unknown,
   path: ReadonlyArray<string> = [],
-  isSerializable: (value: unknown) => boolean = isPlain
+  isSerializable: (value: unknown) => boolean = isPlain,
+  getEntries?: (value: unknown) => [string, any][]
 ): NonSerializableValue | false {
   let foundNestedSerializable: NonSerializableValue | false
 
@@ -55,9 +56,10 @@ export function findNonSerializableValue(
     return false
   }
 
-  for (const property of Object.keys(value)) {
+  const entries = getEntries != null ? getEntries(value) : Object.entries(value);
+
+  for (const [property, nestedValue] of entries) {
     const nestedPath = path.concat(property)
-    const nestedValue: unknown = (value as any)[property]
 
     if (!isSerializable(nestedValue)) {
       return {
@@ -70,7 +72,8 @@ export function findNonSerializableValue(
       foundNestedSerializable = findNonSerializableValue(
         nestedValue,
         nestedPath,
-        isSerializable
+        isSerializable,
+        getEntries
       )
 
       if (foundNestedSerializable) {
@@ -91,7 +94,13 @@ export interface SerializableStateInvariantMiddlewareOptions {
    * function is applied recursively to every value contained in the
    * state. Defaults to `isPlain()`.
    */
-  isSerializable?: (value: any) => boolean
+  isSerializable?: (value: any) => boolean,
+  /**
+   * The function that will be used to retrieve entries from each
+   * value.  If unspecified, `Object.entries` will be used. Defaults
+   * to `undefined`.
+   */
+  getEntries?: (value: any) => [string, any][],
 }
 
 /**
@@ -104,13 +113,14 @@ export interface SerializableStateInvariantMiddlewareOptions {
 export function createSerializableStateInvariantMiddleware(
   options: SerializableStateInvariantMiddlewareOptions = {}
 ): Middleware {
-  const { isSerializable = isPlain } = options
+  const { isSerializable = isPlain, getEntries } = options
 
   return storeAPI => next => action => {
     const foundActionNonSerializableValue = findNonSerializableValue(
       action,
       [],
-      isSerializable
+      isSerializable,
+      getEntries,
     )
 
     if (foundActionNonSerializableValue) {
@@ -123,7 +133,12 @@ export function createSerializableStateInvariantMiddleware(
 
     const state = storeAPI.getState()
 
-    const foundStateNonSerializableValue = findNonSerializableValue(state)
+    const foundStateNonSerializableValue = findNonSerializableValue(
+      state,
+      [],
+      isSerializable,
+      getEntries,
+      )
 
     if (foundStateNonSerializableValue) {
       const { keyPath, value } = foundStateNonSerializableValue


### PR DESCRIPTION
In Issue #140 I said I would wait before submitting a PR, but here we are.

This pull request will enhance `serializable-state-invariant-middleware` to accept an additional option at creation: `getEntries`.  Additionally, it will use the `isSerializable` when checking action and state.

These two options will allow a consumer to augment the middleware to tolerate certain structures, such as ImmutableJS.  In the example below, the consumer is configuring the middleware to permit `immutable` structures and consider them to be serializable:

```js
// immutable version 3.8.2 assumed for this demo!
const isSerializable = (value: any): boolean =>
  Iterable.isIterable(value) || isPlain(value);

const getEntries = (value: any): [string, any][] =>
  Iterable.isIterable(value) ? value.entries() : Object.entries(value);

const middleware = createSerializableStateInvariantMiddleware({
  isSerializable,
  getEntries,
});
```
