### PR TITLE
Docs: Fix mutating state example.

### DIFF
--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -223,7 +223,7 @@ Can be simplified down to just:
 ```js
 updateValue(state, action) {
     const {someId, someValue} = action.payload;
-    state.first.second[someId] = someValue;
+    state.first.second[someId].fourth = someValue;
 }
 ```
 


### PR DESCRIPTION
The comparison example on how to "mutate" state was not targeting the correct state property.