### PR TITLE
add prepareAction option to createAction

### DIFF
--- a/src/createAction.test.ts
+++ b/src/createAction.test.ts
@@ -15,6 +15,50 @@ describe('createAction', () => {
       expect(`${actionCreator}`).toEqual('A_TYPE')
     })
   })
+
+  describe('when passing a prepareAction method only returning a payload', () => {
+    it('should use the payload returned from the prepareAction method', () => {
+      const actionCreator = createAction('A_TYPE', (a: number) => ({
+        payload: a * 2
+      }))
+      expect(actionCreator(5).payload).toBe(10)
+    })
+    it('should not have a meta attribute on the resulting Action', () => {
+      const actionCreator = createAction('A_TYPE', (a: number) => ({
+        payload: a * 2
+      }))
+      expect('meta' in actionCreator(5)).toBeFalsy()
+    })
+  })
+
+  describe('when passing a prepareAction method returning a payload and meta', () => {
+    it('should use the payload returned from the prepareAction method', () => {
+      const actionCreator = createAction('A_TYPE', (a: number) => ({
+        payload: a * 2,
+        meta: a / 2
+      }))
+      expect(actionCreator(5).payload).toBe(10)
+    })
+    it('should use the meta returned from the prepareAction method', () => {
+      const actionCreator = createAction('A_TYPE', (a: number) => ({
+        payload: a * 2,
+        meta: a / 2
+      }))
+      expect(actionCreator(10).meta).toBe(5)
+    })
+  })
+
+  describe('when passing a prepareAction that accepts multiple arguments', () => {
+    it('should pass all arguments of the resulting actionCreator to prepareAction', () => {
+      const actionCreator = createAction(
+        'A_TYPE',
+        (a: string, b: string, c: string) => ({
+          payload: a + b + c
+        })
+      )
+      expect(actionCreator('1', '2', '3').payload).toBe('123')
+    })
+  })
 })
 
 describe('getType', () => {

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -18,8 +18,8 @@ export type PayloadAction<
 export type Diff<T, U> = T extends U ? never : T
 
 export type PrepareAction<P> =
-  | ((...args: any) => { payload: P })
-  | ((...args: any) => { payload: P; meta: any })
+  | ((...args: any[]) => { payload: P })
+  | ((...args: any[]) => { payload: P; meta: any })
 
 /**
  * An action creator that produces actions with a `payload` attribute.
@@ -30,7 +30,7 @@ export type PayloadActionCreator<
   PA extends PrepareAction<P> | void = void
 > = {
   type: T
-} & (PA extends (...args: any) => any
+} & (PA extends (...args: any[]) => any
   ? (ReturnType<PA> extends { meta: infer M }
       ? (...args: Parameters<PA>) => PayloadAction<P, T, M>
       : (...args: Parameters<PA>) => PayloadAction<P, T>)
@@ -78,6 +78,9 @@ export function createAction(type: string, prepareAction?: Function) {
   function actionCreator(...args: any[]) {
     if (prepareAction) {
       let prepared = prepareAction(...args)
+      if (!prepared) {
+        throw new Error('prepareAction did not return an object')
+      }
       return 'meta' in prepared
         ? { type, payload: prepared.payload, meta: prepared.meta }
         : { type, payload: prepared.payload }

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -7,33 +7,50 @@ import { Action } from 'redux'
  * @template P The type of the action's payload.
  * @template T the type used for the action type.
  */
-export interface PayloadAction<P = any, T extends string = string>
-  extends Action<T> {
+export type PayloadAction<
+  P = any,
+  T extends string = string,
+  M = void
+> = Action<T> & {
   payload: P
-}
+} & ([M] extends [void] ? {} : { meta: M })
 
-export type Diff<T, U> = T extends U ? never : T;
+export type Diff<T, U> = T extends U ? never : T
+
+export type PrepareAction<P> =
+  | ((...args: any) => { payload: P })
+  | ((...args: any) => { payload: P; meta: any })
 
 /**
  * An action creator that produces actions with a `payload` attribute.
  */
-export type PayloadActionCreator<P = any, T extends string = string> = { type: T } & (
-  /*
-  * The `P` generic is wrapped with a single-element tuple to prevent the
-  * conditional from being checked distributively, thus preserving unions
-  * of contra-variant types.
-  */
-  [undefined] extends [P] ? {
-    (payload?: undefined): PayloadAction<undefined, T>
-    <PT extends Diff<P, undefined>>(payload?: PT): PayloadAction<PT, T>
-  }
-  : [void] extends [P] ? {
-    (): PayloadAction<undefined, T>
-  }
-  : {
-    <PT extends P>(payload: PT): PayloadAction<PT, T>
-  }
-);
+export type PayloadActionCreator<
+  P = any,
+  T extends string = string,
+  PA extends PrepareAction<P> | void = void
+> = {
+  type: T
+} & (PA extends (...args: any) => any
+  ? (ReturnType<PA> extends { meta: infer M }
+      ? (...args: Parameters<PA>) => PayloadAction<P, T, M>
+      : (...args: Parameters<PA>) => PayloadAction<P, T>)
+  : (/*
+     * The `P` generic is wrapped with a single-element tuple to prevent the
+     * conditional from being checked distributively, thus preserving unions
+     * of contra-variant types.
+     */
+    [undefined] extends [P]
+      ? {
+          (payload?: undefined): PayloadAction<undefined, T>
+          <PT extends Diff<P, undefined>>(payload?: PT): PayloadAction<PT, T>
+        }
+      : [void] extends [P]
+      ? {
+          (): PayloadAction<undefined, T>
+        }
+      : {
+          <PT extends P>(payload: PT): PayloadAction<PT, T>
+        }))
 
 /**
  * A utility function to create an action creator for the given action type
@@ -44,18 +61,35 @@ export type PayloadActionCreator<P = any, T extends string = string> = { type: T
  *
  * @param type The action type to use for created actions.
  */
+
 export function createAction<P = any, T extends string = string>(
   type: T
-): PayloadActionCreator<P, T> {
-  function actionCreator(payload?: P): PayloadAction<undefined | P, T> {
-    return { type, payload }
+): PayloadActionCreator<P, T>
+
+export function createAction<
+  PA extends PrepareAction<any>,
+  T extends string = string
+>(
+  type: T,
+  prepareAction: PA
+): PayloadActionCreator<ReturnType<PA>['payload'], T, PA>
+
+export function createAction(type: string, prepareAction?: Function) {
+  function actionCreator(...args: any[]) {
+    if (prepareAction) {
+      let prepared = prepareAction(...args)
+      return 'meta' in prepared
+        ? { type, payload: prepared.payload, meta: prepared.meta }
+        : { type, payload: prepared.payload }
+    }
+    return { type, payload: args[0] }
   }
 
-  actionCreator.toString = (): T => `${type}` as T
+  actionCreator.toString = () => `${type}`
 
   actionCreator.type = type
 
-  return actionCreator as any
+  return actionCreator
 }
 
 /**

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -1,16 +1,10 @@
 import createNextState, { Draft } from 'immer'
 import { AnyAction, Action, Reducer } from 'redux'
-import { PrepareAction, PayloadAction } from './createAction'
 
 /**
  * Defines a mapping from action types to corresponding action object shapes.
  */
 export type Actions<T extends keyof any = string> = Record<T, Action>
-
-export type EnhancedReducer<S = any, A extends Action = AnyAction> = {
-  prepare: PrepareAction<A extends { payload: infer P } ? P : undefined>
-  reducer: CaseReducer<S, A>
-}
 
 /**
  * An *case reducer* is a reducer function for a speficic action type. Case
@@ -35,15 +29,7 @@ export type CaseReducer<S = any, A extends Action = AnyAction> = (
  * A mapping from action types to case reducers for `createReducer()`.
  */
 export type CaseReducers<S, AS extends Actions> = {
-  [T in keyof AS]:
-    | CaseReducer<S, AS[T]>
-    | (AS[T] extends PayloadAction ? EnhancedReducer<S, AS[T]> : never)
-}
-
-export function isEnhancedReducer<S, A extends Action>(
-  caseReducer: CaseReducer<S, A> | EnhancedReducer<S, A> | void
-): caseReducer is EnhancedReducer<S, A> {
-  return !!caseReducer && 'reducer' in caseReducer
+  [T in keyof AS]: AS[T] extends Action ? CaseReducer<S, AS[T]> : void
 }
 
 /**
@@ -72,11 +58,7 @@ export function createReducer<
     // these two types.
     return createNextState(state, (draft: Draft<S>) => {
       const caseReducer = actionsMap[action.type]
-      return !caseReducer
-        ? undefined
-        : isEnhancedReducer(caseReducer)
-        ? caseReducer.reducer(draft, action)
-        : caseReducer(draft, action)
+      return caseReducer ? caseReducer(draft, action) : undefined
     })
   }
 }

--- a/src/createSlice.test.ts
+++ b/src/createSlice.test.ts
@@ -128,4 +128,48 @@ describe('createSlice', () => {
       expect(result).toBe(15)
     })
   })
+
+  describe('behaviour with enhanced case reducers', () => {
+    it('should pass all arguments to the prepare function', () => {
+      const prepare = jest.fn((payload, somethingElse) => ({ payload }))
+
+      const testSlice = createSlice({
+        slice: 'test',
+        initialState: 0,
+        reducers: {
+          testReducer: {
+            reducer: s => s,
+            prepare
+          }
+        }
+      })
+
+      expect(testSlice.actions.testReducer('a', 1)).toEqual({
+        type: 'test/testReducer',
+        payload: 'a'
+      })
+      expect(prepare).toHaveBeenCalledWith('a', 1)
+    })
+
+    it('should call the reducer function', () => {
+      const reducer = jest.fn()
+
+      const testSlice = createSlice({
+        slice: 'test',
+        initialState: 0,
+        reducers: {
+          testReducer: {
+            reducer,
+            prepare: payload => ({ payload })
+          }
+        }
+      })
+
+      testSlice.reducer(0, testSlice.actions.testReducer('testPayload'))
+      expect(reducer).toHaveBeenCalledWith(
+        0,
+        expect.objectContaining({ payload: 'testPayload' })
+      )
+    })
+  })
 })

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -98,6 +98,17 @@ type CaseReducerActions<CR extends SliceCaseReducers<any, any>> = {
         : PayloadActionCreator<void>)
 }
 
+type NoInfer<T> = [T][T extends any ? 0 : never];
+type SliceCaseReducersCheck<S, ACR> = {
+    [P in keyof ACR] : ACR[P] extends {
+        reducer(s:S, action?: { payload: infer O }): any 
+    } ? {
+        prepare(...a:never[]): { payload: O }
+    } : {
+
+    }
+}
+
 function getType(slice: string, actionKey: string): string {
   return slice ? `${slice}/${actionKey}` : actionKey
 }
@@ -110,6 +121,9 @@ function getType(slice: string, actionKey: string): string {
  *
  * The `reducer` argument is passed to `createReducer()`.
  */
+export function createSlice<S, CR extends SliceCaseReducers<S, any>>(
+  options: CreateSliceOptions<S, CR> & { reducers: SliceCaseReducersCheck<S, NoInfer<CR>> }
+): Slice<S, CaseReducerActions<CR>>
 export function createSlice<S, CR extends SliceCaseReducers<S, any>>(
   options: CreateSliceOptions<S, CR>
 ): Slice<S, CaseReducerActions<CR>> {

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -7,7 +7,9 @@ import {
   AnyAction
 } from 'redux-starter-kit'
 
-function expectType<T>(p: T) { }
+function expectType<T>(p: T): T {
+  return p
+}
 
 /* PayloadAction */
 
@@ -64,14 +66,14 @@ function expectType<T>(p: T) { }
     { type: 'action' }
   ) as PayloadActionCreator
 
-  expectType<PayloadAction<number>>(actionCreator(1));
-  expectType<PayloadAction<undefined>>(actionCreator());
-  expectType<PayloadAction<undefined>>(actionCreator(undefined));
+  expectType<PayloadAction<number>>(actionCreator(1))
+  expectType<PayloadAction<undefined>>(actionCreator())
+  expectType<PayloadAction<undefined>>(actionCreator(undefined))
 
   // typings:expect-error
-  expectType<PayloadAction<number>>(actionCreator());
+  expectType<PayloadAction<number>>(actionCreator())
   // typings:expect-error
-  expectType<PayloadAction<undefined>>(actionCreator(1));
+  expectType<PayloadAction<undefined>>(actionCreator(1))
 }
 
 /*
@@ -110,7 +112,7 @@ function expectType<T>(p: T) { }
   const n: number = increment(1).payload
 
   // typings:expect-error
-  increment("").payload
+  increment('').payload
 }
 
 /*
@@ -119,7 +121,7 @@ function expectType<T>(p: T) { }
 {
   const increment = createAction('increment')
   const n: number = increment(1).payload
-  const s: string = increment("1").payload
+  const s: string = increment('1').payload
 
   // but infers the payload type to be the argument type
   // typings:expect-error
@@ -137,4 +139,43 @@ function expectType<T>(p: T) { }
   const r: 'other' = increment(1).type
   // typings:expect-error
   const q: number = increment(1).type
+}
+
+/*
+ * Test: type still present when using prepareAction
+ */
+{
+  const strLenAction = createAction('strLen', (payload: string) => ({
+    payload: payload.length
+  }))
+
+  expectType<string>(strLenAction('test').type)
+}
+
+/*
+ * Test: changing payload type with prepareAction
+ */
+{
+  const strLenAction = createAction('strLen', (payload: string) => ({
+    payload: payload.length
+  }))
+  expectType<number>(strLenAction('test').payload)
+
+  // typings:expect-error
+  expectType<string>(strLenAction('test').payload)
+}
+
+/*
+ * Test: adding metadata with prepareAction
+ */
+{
+  const strLenMetaAction = createAction('strLenMeta', (payload: string) => ({
+    payload,
+    meta: payload.length
+  }))
+
+  expectType<number>(strLenMetaAction('test').meta)
+
+  // typings:expect-error
+  expectType<string>(strLenMetaAction('test').meta)
 }

--- a/type-tests/files/createReducer.typetest.ts
+++ b/type-tests/files/createReducer.typetest.ts
@@ -1,4 +1,11 @@
-import { AnyAction, createReducer, Reducer } from 'redux-starter-kit'
+import {
+  AnyAction,
+  createReducer,
+  Reducer,
+  PayloadAction
+} from 'redux-starter-kit'
+
+function expectType<T>(p: T) {}
 
 /*
  * Test: createReducer() infers type of returned reducer.
@@ -59,4 +66,29 @@ import { AnyAction, createReducer, Reducer } from 'redux-starter-kit'
       state.counter += 1
     }
   })
+}
+
+/*
+ * Test: createReducer accepts EnhancedReducer
+ */
+{
+  // TODO: is this possible to type? currently unfortunately failing
+  // prepared payload does not match action payload - should cause an error
+
+  // typings:expect-error
+  createReducer(
+    { counter: 0 },
+    {
+      increment: {
+        reducer(state, action) {
+          state.counter += action.payload.length
+        },
+        prepare() {
+          return {
+            payload: 6
+          }
+        }
+      }
+    }
+  )
 }

--- a/type-tests/files/createReducer.typetest.ts
+++ b/type-tests/files/createReducer.typetest.ts
@@ -67,28 +67,3 @@ function expectType<T>(p: T) {}
     }
   })
 }
-
-/*
- * Test: createReducer accepts EnhancedReducer
- */
-{
-  // TODO: is this possible to type? currently unfortunately failing
-  // prepared payload does not match action payload - should cause an error
-
-  // typings:expect-error
-  createReducer(
-    { counter: 0 },
-    {
-      increment: {
-        reducer(state, action) {
-          state.counter += action.payload.length
-        },
-        prepare() {
-          return {
-            payload: 6
-          }
-        }
-      }
-    }
-  )
-}

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -6,6 +6,10 @@ import {
   createAction
 } from 'redux-starter-kit'
 
+function expectType<T>(t: T) {
+  return t
+}
+
 /*
  * Test: createSlice() infers the returned slice's type.
  */
@@ -78,8 +82,6 @@ import {
   counter.actions.multiply('2')
 }
 
-
-
 /*
  * Test: Slice action creator types properties are "string"
  */
@@ -97,12 +99,48 @@ import {
     }
   })
 
-  const s: string = counter.actions.increment.type;
-  const t: string = counter.actions.decrement.type;
-  const u: string = counter.actions.multiply.type;
+  const s: string = counter.actions.increment.type
+  const t: string = counter.actions.decrement.type
+  const u: string = counter.actions.multiply.type
 
   // typings:expect-error
-  const x: "counter/increment" = counter.actions.increment.type;
+  const x: 'counter/increment' = counter.actions.increment.type
   // typings:expect-error
-  const y: "increment" = counter.actions.increment.type;
+  const y: 'increment' = counter.actions.increment.type
+}
+
+/*
+ * Test: Slice action creator types are inferred for enhanced reducers.
+ */
+{
+  const counter = createSlice({
+    slice: 'counter',
+    initialState: 0,
+    reducers: {
+      strLen: {
+        reducer: s => s,
+        prepare: (payload: string) => ({
+          payload: payload.length
+        })
+      },
+      strLenMeta: {
+        reducer: s => s,
+        prepare: (payload: string) => ({
+          payload,
+          meta: payload.length
+        })
+      }
+    }
+  })
+
+  expectType<string>(counter.actions.strLen('test').type)
+  expectType<number>(counter.actions.strLen('test').payload)
+  expectType<string>(counter.actions.strLenMeta('test').payload)
+  expectType<number>(counter.actions.strLenMeta('test').meta)
+
+  // typings:expect-error
+  expectType<string>(counter.actions.strLen('test').payload)
+
+  // typings:expect-error
+  expectType<string>(counter.actions.strLenMeta('test').meta)
 }

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -67,19 +67,29 @@ function expectType<T>(t: T) {
       multiply: (state, { payload }: PayloadAction<number | number[]>) =>
         Array.isArray(payload)
           ? payload.reduce((acc, val) => acc * val, state)
-          : state * payload
+          : state * payload,
+      addTwo: {
+        reducer: (s, { payload }) => s + payload,
+        prepare: (a: number, b: number) => ({
+          payload: a + b
+        })
+      }
     }
   })
 
   counter.actions.increment()
   counter.actions.multiply(2)
   counter.actions.multiply([2, 3, 4])
+  counter.actions.addTwo(1, 2)
 
   // typings:expect-error
   counter.actions.multiply()
 
   // typings:expect-error
   counter.actions.multiply('2')
+
+  // typings:expect-error
+  counter.actions.addTwo(1)
 }
 
 /*
@@ -143,4 +153,35 @@ function expectType<T>(t: T) {
 
   // typings:expect-error
   expectType<string>(counter.actions.strLenMeta('test').meta)
+}
+
+/*
+ * Test: createReducer accepts EnhancedReducer
+ */
+{
+  /*
+    TODO: is this possible to type? currently unfortunately failing
+    prepared payload does not match action payload - should cause an error.
+
+    But instead it seems to just loosen the type to EnhancedCaseReducer<S, PayloadAction<any>>, 
+    in which case the CaseReducer<S, PayloadAction<string>> and PrepareAction<number> aren't colliding any more.
+  */
+
+  // typings:expect-error
+  const counter = createSlice({
+    slice: 'counter',
+    initialState: { counter: 0 },
+    reducers: {
+      increment: {
+        reducer(state, action: PayloadAction<string>) {
+          state.counter += action.payload.length
+        },
+        prepare(x: string) {
+          return {
+            payload: 6
+          }
+        }
+      }
+    }
+  })
 }

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -124,17 +124,21 @@ function expectType<T>(t: T) {
  */
 {
   const counter = createSlice({
-    slice: 'counter',
-    initialState: 0,
+    slice: 'test',
+    initialState: { counter: 0, concat: "" },
     reducers: {
-      strLen: {
-        reducer: s => s,
+      incrementByStrLen: {
+        reducer: (state, action: PayloadAction<number>) => {
+          state.counter += action.payload
+        },
         prepare: (payload: string) => ({
           payload: payload.length
         })
       },
-      strLenMeta: {
-        reducer: s => s,
+      concatMetaStrLen: {
+        reducer: (state, action: PayloadAction<string>) => {
+          state.concat += action.payload
+        },
         prepare: (payload: string) => ({
           payload,
           meta: payload.length
@@ -143,10 +147,10 @@ function expectType<T>(t: T) {
     }
   })
 
-  expectType<string>(counter.actions.strLen('test').type)
-  expectType<number>(counter.actions.strLen('test').payload)
-  expectType<string>(counter.actions.strLenMeta('test').payload)
-  expectType<number>(counter.actions.strLenMeta('test').meta)
+  expectType<string>(counter.actions.incrementByStrLen('test').type)
+  expectType<number>(counter.actions.incrementByStrLen('test').payload)
+  expectType<string>(counter.actions.concatMetaStrLen('test').payload)
+  expectType<number>(counter.actions.concatMetaStrLen('test').meta)
 
   // typings:expect-error
   expectType<string>(counter.actions.strLen('test').payload)
@@ -156,17 +160,9 @@ function expectType<T>(t: T) {
 }
 
 /*
- * Test: createReducer accepts EnhancedReducer
+ * Test: prepared payload does not match action payload - should cause an error.
  */
 {
-  /*
-    TODO: is this possible to type? currently unfortunately failing
-    prepared payload does not match action payload - should cause an error.
-
-    But instead it seems to just loosen the type to EnhancedCaseReducer<S, PayloadAction<any>>, 
-    in which case the CaseReducer<S, PayloadAction<string>> and PrepareAction<number> aren't colliding any more.
-  */
-
   // typings:expect-error
   const counter = createSlice({
     slice: 'counter',


### PR DESCRIPTION
This is a rough WIP for the feature requested in #148. Essentially, it allows to pass a `prepare` function with the signature `(originalPayload: OriginalPayload) => {payload: Payload; meta? : Meta}` to modify the Payload and potentially add a Meta to the created action. You can see examples of use in the type tests I added.

This is working, but needs tuning around the types - but before that I would like some feedback if I'm going in the right direction with this.

@markerikson  @tanhauhau what do you think?
