### PR TITLE
infer action creators from `createSlice`  as `PayloadActionCreator`

### DIFF
--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -12,14 +12,43 @@ export interface PayloadAction<P = any, T extends string = string>
   payload: P
 }
 
+export type Diff<T, U> = T extends U ? never : T;
+
 /**
  * An action creator that produces actions with a `payload` attribute.
  */
-export interface PayloadActionCreator<P = any, T extends string = string> {
-  (): Action<T>
-  (payload: P): PayloadAction<P, T>
-  type: T
-}
+export type PayloadActionCreator<P = any, T extends string = string> = { type: T } & (
+  /*
+  * The `P` generic is wrapped with a single-element tuple to prevent the
+  * conditional from being checked distributively, thus preserving unions
+  * of contra-variant types.
+  */
+  [undefined] extends [P] ? {
+    // not sure which behavious fits better
+
+    /*
+    * actionCreator() => Action<T>
+    * actionCreator(undefined) => Action<T>
+    * actionCreator("foo") => PayloadAction<"foo", T>
+    */
+    (payload?: undefined): Action<T>
+    <PT extends Diff<P, undefined>>(payload?: PT): PayloadAction<PT, T>
+
+    /*
+    * actionCreator() => Action<T>
+    * actionCreator(undefined) => PayloadAction<undefined, T>
+    * actionCreator("foo") => PayloadAction<"foo", T>
+    */
+    // (): Action<T>
+    // <PT extends P>(payload: PT): PayloadAction<PT, T>
+  }
+  : [void] extends [P] ? {
+    (): Action<T>
+  }
+  : {
+    <PT extends P>(payload: PT): PayloadAction<PT, T>
+  }
+);
 
 /**
  * A utility function to create an action creator for the given action type
@@ -33,8 +62,6 @@ export interface PayloadActionCreator<P = any, T extends string = string> {
 export function createAction<P = any, T extends string = string>(
   type: T
 ): PayloadActionCreator<P, T> {
-  function actionCreator(): Action<T>
-  function actionCreator(payload: P): PayloadAction<P, T>
   function actionCreator(payload?: P): Action<T> | PayloadAction<P, T> {
     return { type, payload }
   }
@@ -43,7 +70,7 @@ export function createAction<P = any, T extends string = string>(
 
   actionCreator.type = type
 
-  return actionCreator
+  return actionCreator as any
 }
 
 /**

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -24,26 +24,11 @@ export type PayloadActionCreator<P = any, T extends string = string> = { type: T
   * of contra-variant types.
   */
   [undefined] extends [P] ? {
-    // not sure which behavious fits better
-
-    /*
-    * actionCreator() => Action<T>
-    * actionCreator(undefined) => Action<T>
-    * actionCreator("foo") => PayloadAction<"foo", T>
-    */
-    (payload?: undefined): Action<T>
+    (payload?: undefined): PayloadAction<undefined, T>
     <PT extends Diff<P, undefined>>(payload?: PT): PayloadAction<PT, T>
-
-    /*
-    * actionCreator() => Action<T>
-    * actionCreator(undefined) => PayloadAction<undefined, T>
-    * actionCreator("foo") => PayloadAction<"foo", T>
-    */
-    // (): Action<T>
-    // <PT extends P>(payload: PT): PayloadAction<PT, T>
   }
   : [void] extends [P] ? {
-    (): Action<T>
+    (): PayloadAction<undefined, T>
   }
   : {
     <PT extends P>(payload: PT): PayloadAction<PT, T>
@@ -62,7 +47,7 @@ export type PayloadActionCreator<P = any, T extends string = string> = { type: T
 export function createAction<P = any, T extends string = string>(
   type: T
 ): PayloadActionCreator<P, T> {
-  function actionCreator(payload?: P): Action<T> | PayloadAction<P, T> {
+  function actionCreator(payload?: P): PayloadAction<undefined | P, T> {
     return { type, payload }
   }
 

--- a/src/createSlice.ts
+++ b/src/createSlice.ts
@@ -1,5 +1,5 @@
 import { Reducer } from 'redux'
-import { createAction, PayloadAction, PayloadActionCreator, Diff } from './createAction'
+import { createAction, PayloadAction, PayloadActionCreator } from './createAction'
 import { createReducer, CaseReducers } from './createReducer'
 import { createSliceSelector, createSelectorName } from './sliceSelector'
 
@@ -28,7 +28,7 @@ export interface Slice<
    * Action creators for the types of actions that are handled by the slice
    * reducer.
    */
-  actions: { [type in keyof AP]: PayloadActionCreator<AP[type], Diff<type, number | symbol>> }
+  actions: { [type in keyof AP]: PayloadActionCreator<AP[type]> }
 
   /**
    * Selectors for the slice reducer state. `createSlice()` inserts a single

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -7,6 +7,8 @@ import {
   AnyAction
 } from 'redux-starter-kit'
 
+function expectType<T>(p: T) { }
+
 /* PayloadAction */
 
 /*
@@ -50,7 +52,7 @@ import {
 /* PayloadActionCreator */
 
 /*
- * Test: PayloadActionCreator returns Action or PayloadAction depending
+ * Test: PayloadActionCreator returns correctly typed PayloadAction depending
  * on whether a payload is passed.
  */
 {
@@ -62,16 +64,14 @@ import {
     { type: 'action' }
   ) as PayloadActionCreator
 
-  let action: Action
-  let payloadAction: PayloadAction
-
-  action = actionCreator()
-  action = actionCreator(undefined)
-  action = actionCreator(1)
-  payloadAction = actionCreator(1)
+  expectType<PayloadAction<number>>(actionCreator(1));
+  expectType<PayloadAction<undefined>>(actionCreator());
+  expectType<PayloadAction<undefined>>(actionCreator(undefined));
 
   // typings:expect-error
-  payloadAction = actionCreator()
+  expectType<PayloadAction<number>>(actionCreator());
+  // typings:expect-error
+  expectType<PayloadAction<undefined>>(actionCreator(1));
 }
 
 /*

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -54,18 +54,19 @@ import {
  * on whether a payload is passed.
  */
 {
-  const actionCreator: PayloadActionCreator = Object.assign(
+  const actionCreator = Object.assign(
     (payload?: number) => ({
       type: 'action',
       payload
     }),
     { type: 'action' }
-  )
+  ) as PayloadActionCreator
 
   let action: Action
   let payloadAction: PayloadAction
 
   action = actionCreator()
+  action = actionCreator(undefined)
   action = actionCreator(1)
   payloadAction = actionCreator(1)
 
@@ -77,22 +78,22 @@ import {
  * Test: PayloadActionCreator is compatible with ActionCreator.
  */
 {
-  const payloadActionCreator: PayloadActionCreator = Object.assign(
+  const payloadActionCreator = Object.assign(
     (payload?: number) => ({
       type: 'action',
       payload
     }),
     { type: 'action' }
-  )
+  ) as PayloadActionCreator
   const actionCreator: ActionCreator<AnyAction> = payloadActionCreator
 
-  const payloadActionCreator2: PayloadActionCreator<number> = Object.assign(
+  const payloadActionCreator2 = Object.assign(
     (payload?: number) => ({
       type: 'action',
       payload: payload || 1
     }),
     { type: 'action' }
-  )
+  ) as PayloadActionCreator<number>
 
   const actionCreator2: ActionCreator<
     PayloadAction<number>
@@ -109,7 +110,7 @@ import {
   const n: number = increment(1).payload
 
   // typings:expect-error
-  const s: string = increment(1).payload
+  increment("").payload
 }
 
 /*
@@ -118,7 +119,11 @@ import {
 {
   const increment = createAction('increment')
   const n: number = increment(1).payload
-  const s: string = increment(1).payload
+  const s: string = increment("1").payload
+
+  // but infers the payload type to be the argument type
+  // typings:expect-error
+  const t: string = increment(1).payload
 }
 /*
  * Test: createAction().type is a string literal.

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -81,7 +81,7 @@ import {
 
 
 /*
- * Test: Slice action creator types properties are correct
+ * Test: Slice action creator types properties are "string"
  */
 {
   const counter = createSlice({
@@ -97,7 +97,12 @@ import {
     }
   })
 
-  const x: "increment" = counter.actions.increment.type;
-  const y: "decrement" = counter.actions.decrement.type;
-  const z: "multiply" = counter.actions.multiply.type;
+  const s: string = counter.actions.increment.type;
+  const t: string = counter.actions.decrement.type;
+  const u: string = counter.actions.multiply.type;
+
+  // typings:expect-error
+  const x: "counter/increment" = counter.actions.increment.type;
+  // typings:expect-error
+  const y: "increment" = counter.actions.increment.type;
 }

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -77,3 +77,27 @@ import {
   // typings:expect-error
   counter.actions.multiply('2')
 }
+
+
+
+/*
+ * Test: Slice action creator types properties are correct
+ */
+{
+  const counter = createSlice({
+    slice: 'counter',
+    initialState: 0,
+    reducers: {
+      increment: state => state + 1,
+      decrement: state => state - 1,
+      multiply: (state, { payload }: PayloadAction<number | number[]>) =>
+        Array.isArray(payload)
+          ? payload.reduce((acc, val) => acc * val, state)
+          : state * payload
+    }
+  })
+
+  const x: "increment" = counter.actions.increment.type;
+  const y: "decrement" = counter.actions.decrement.type;
+  const z: "multiply" = counter.actions.multiply.type;
+}


### PR DESCRIPTION
see #157 

This changes the createSlice types to use PayloadActionCreator and modifies the behaviour of PayloadActionCreator to account for `P = void` and `P = Something | undefined`.

Here are some examples:

```typescript

const someNumber: number = 5;
const someString: string = "";

const voidActionCreator = createAction<void>('a');
voidActionCreator(); // Action<'a'>
voidActionCreator(undefined); // Action<'a'>

const stringActionCreator = createAction<string>('b');
stringActionCreator('x'); // PayloadAction<'x', 'b'>

const optionalStringActionCreator = createAction<string | undefined>('c');
optionalStringActionCreator(); // Action<'c'>
optionalStringActionCreator(undefined); // Action<'c'>
optionalStringActionCreator('x') // PayloadAction<'x', 'c'>

const mixedActionCreator = createAction<string | number>('d');
mixedActionCreator('x') // PayloadAction<'x', 'd'>
mixedActionCreator(someNumber) // PayloadAction<number, 'd'>
mixedActionCreator(5) // PayloadAction<5, 'd'>
mixedActionCreator(someString) // PayloadAction<string, 'd'>

const anyActionCreator = createAction('e');
anyActionCreator() // Action<'e'>
anyActionCreator(someNumber) // PayloadAction<number, 'e'>
anyActionCreator(5) // PayloadAction<5, 'e'>
anyActionCreator(someString) // PayloadAction<string, 'e'>
```

so payload types are now interfered much more accurate, which is especially useful for the `<any>` case.

There is one open question open regarding the typing of the `undefined` argument: if `undefined` is not omitted, but explicitly specified, should we return an Action or a PayloadAction<undefined>? (See https://github.com/reduxjs/redux-starter-kit/pull/158/files#diff-437575fb1d5c39e3edd424ab38899f8eR27 )

PS: I could easily do away with the excessive type interference, but that would hurt the  `<any>` case a bit in my eyes and I think it won't hurt, so I'm looking forward to your opinion on it ;)