### PR TITLE
Use `void` instead of `any` for undefined payloads

### DIFF
--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -10,7 +10,7 @@ import { IsUnknownOrNonInferrable } from './tsHelpers'
  * @template M The type of the action's meta (optional)
  */
 export type PayloadAction<
-  P = any,
+  P = void,
   T extends string = string,
   M = void
 > = WithOptionalMeta<M, WithPayload<P, Action<T>>>
@@ -62,7 +62,7 @@ export type ActionCreatorWithPayload<
  * An action creator that produces actions with a `payload` attribute.
  */
 export type PayloadActionCreator<
-  P = any,
+  P = void,
   T extends string = string,
   PA extends PrepareAction<P> | void = void
 > = IfPrepareActionMethodProvided<
@@ -94,7 +94,7 @@ export type PayloadActionCreator<
  *                If this is given, the resulting action creator will pass it's arguments to this method to calculate payload & meta.
  */
 
-export function createAction<P = any, T extends string = string>(
+export function createAction<P = void, T extends string = string>(
   type: T
 ): PayloadActionCreator<P, T>
 

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -19,7 +19,7 @@ function expectType<T>(p: T): T {
 }
 
 /*
- * Test: PayloadAction type parameter is optional (defaults to `any`).
+ * Test: PayloadAction type parameter is required.
  */
 {
   // typings:expect-error
@@ -61,12 +61,10 @@ function expectType<T>(p: T): T {
       payload
     }),
     { type: 'action' }
-  ) as PayloadActionCreator<number>
+  ) as PayloadActionCreator<number | undefined>
 
   expectType<PayloadAction<number>>(actionCreator(1))
-  // typings:expect-error
   expectType<PayloadAction<undefined>>(actionCreator())
-  // typings:expect-error
   expectType<PayloadAction<undefined>>(actionCreator(undefined))
 
   // typings:expect-error
@@ -118,12 +116,9 @@ function expectType<T>(p: T): T {
  * Test: createAction() type parameter is required, not inferred (defaults to `void`).
  */
 {
-  const increment = createAction<number>('increment')
+  const increment = createAction('increment')
+  // typings:expect-error
   const n: number = increment(1).payload
-  // typings:expect-error
-  const s: string = increment('1').payload
-  // typings:expect-error
-  const t: string = increment(1).payload
 }
 /*
  * Test: createAction().type is a string literal.

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -22,8 +22,11 @@ function expectType<T>(p: T): T {
  * Test: PayloadAction type parameter is optional (defaults to `any`).
  */
 {
+  // typings:expect-error
   const action: PayloadAction = { type: '', payload: 5 }
+  // typings:expect-error
   const numberPayload: number = action.payload
+  // typings:expect-error
   const stringPayload: string = action.payload
 }
 
@@ -31,7 +34,7 @@ function expectType<T>(p: T): T {
  * Test: PayloadAction has a string type tag.
  */
 {
-  const action: PayloadAction = { type: '', payload: 5 }
+  const action: PayloadAction<number> = { type: '', payload: 5 }
 
   // typings:expect-error
   const action2: PayloadAction = { type: 1, payload: 5 }
@@ -41,7 +44,7 @@ function expectType<T>(p: T): T {
  * Test: PayloadAction is compatible with Action<string>
  */
 {
-  const action: PayloadAction = { type: '', payload: 5 }
+  const action: PayloadAction<number> = { type: '', payload: 5 }
   const stringAction: Action<string> = action
 }
 
@@ -58,10 +61,12 @@ function expectType<T>(p: T): T {
       payload
     }),
     { type: 'action' }
-  ) as PayloadActionCreator
+  ) as PayloadActionCreator<number>
 
   expectType<PayloadAction<number>>(actionCreator(1))
+  // typings:expect-error
   expectType<PayloadAction<undefined>>(actionCreator())
+  // typings:expect-error
   expectType<PayloadAction<undefined>>(actionCreator(undefined))
 
   // typings:expect-error
@@ -110,14 +115,13 @@ function expectType<T>(p: T): T {
 }
 
 /*
- * Test: createAction() type parameter is optional (defaults to `any`).
+ * Test: createAction() type parameter is required, not inferred (defaults to `void`).
  */
 {
-  const increment = createAction('increment')
+  const increment = createAction<number>('increment')
   const n: number = increment(1).payload
+  // typings:expect-error
   const s: string = increment('1').payload
-
-  // but infers the payload type to be the argument type
   // typings:expect-error
   const t: string = increment(1).payload
 }
@@ -125,7 +129,7 @@ function expectType<T>(p: T): T {
  * Test: createAction().type is a string literal.
  */
 {
-  const increment = createAction('increment')
+  const increment = createAction<number, 'increment'>('increment')
   const n: string = increment(1).type
   const s: 'increment' = increment(1).type
 


### PR DESCRIPTION
Additional layer of type security, don't let the user implicitly opt out of type checking