### PR TITLE
add ignoredActions to createSerializableStateInvariantMiddleware

### DIFF
--- a/docs/api/otherExports.md
+++ b/docs/api/otherExports.md
@@ -15,7 +15,7 @@ Redux Starter Kit exports some of its internal utilities, and re-exports additio
 
 Creates an instance of the `serializable-state-invariant` middleware described in [`getDefaultMiddleware`](./getDefaultMiddleware.md).
 
-Accepts an options object with `isSerializable` and `getEntries` parameters.  The former, `isSerializable`, will be used to determine if a value is considered serializable or not. If not provided, this defaults to `isPlain`.  The latter, `getEntries`, will be used to retrieve nested values.  If not provided, `Object.entries` will be used by default.
+Accepts an options object with `isSerializable` and `getEntries` parameters.  The former, `isSerializable`, will be used to determine if a value is considered serializable or not. If not provided, this defaults to `isPlain`.  The latter, `getEntries`, will be used to retrieve nested values.  If not provided, `Object.entries` will be used by default. `ignoredActions` accepts an array of action types to ignore from serialization check
 
 Example:
 
@@ -34,9 +34,13 @@ const isSerializable = (value) =>
 const getEntries = (value) =>
   Iterable.isIterable(value) ? value.entries() : Object.entries(value)
 
+const ignoredActions = []
+// const ignoredActions = ['persist/PERSIST']
+
 const serializableMiddleware = createSerializableStateInvariantMiddleware({
   isSerializable,
   getEntries,
+  ignoredActions,
 })
 
 const store = configureStore({

--- a/src/configureStore.ts
+++ b/src/configureStore.ts
@@ -30,10 +30,14 @@ const IS_PRODUCTION = process.env.NODE_ENV === 'production'
  *
  * @return The default middleware used by `configureStore()`.
  */
-export function getDefaultMiddleware<S = any, A extends Action = AnyAction>(): [
+export function getDefaultMiddleware<S = any, A extends Action = AnyAction>(data?: any): [
   ThunkMiddleware<S, A>,
   ...Middleware<{}, S>[]
 ] {
+  const {
+    ignoreSerializable = []
+  } = data || {}
+  
   let middlewareArray: [ThunkMiddleware<S, A>, ...Middleware<{}, S>[]] = [thunk]
 
   if (process.env.NODE_ENV !== 'production') {
@@ -43,7 +47,9 @@ export function getDefaultMiddleware<S = any, A extends Action = AnyAction>(): [
     middlewareArray.unshift(createImmutableStateInvariantMiddleware())
     /* STOP_REMOVE_UMD */
 
-    middlewareArray.push(createSerializableStateInvariantMiddleware())
+    middlewareArray.push(
+      createSerializableStateInvariantMiddleware({ ignoredActions: ignoreSerializable })
+    )
   }
 
   return middlewareArray

--- a/src/serializableStateInvariantMiddleware.ts
+++ b/src/serializableStateInvariantMiddleware.ts
@@ -101,6 +101,10 @@ export interface SerializableStateInvariantMiddlewareOptions {
    * to `undefined`.
    */
   getEntries?: (value: any) => [string, any][],
+  /**
+   * An array of ignored actions from serialization check, Defaults to []
+   */
+  ignoredActions?: string[],
 }
 
 /**
@@ -113,9 +117,13 @@ export interface SerializableStateInvariantMiddlewareOptions {
 export function createSerializableStateInvariantMiddleware(
   options: SerializableStateInvariantMiddlewareOptions = {}
 ): Middleware {
-  const { isSerializable = isPlain, getEntries } = options
+  const { isSerializable = isPlain, getEntries, ignoredActions = [] } = options
 
   return storeAPI => next => action => {
+    if (ignoredActions.length && ignoredActions.indexOf(action.type) !== -1) {
+      return next(action)
+    }
+
     const foundActionNonSerializableValue = findNonSerializableValue(
       action,
       [],
@@ -138,7 +146,7 @@ export function createSerializableStateInvariantMiddleware(
       [],
       isSerializable,
       getEntries,
-      )
+    )
 
     if (foundStateNonSerializableValue) {
       const { keyPath, value } = foundStateNonSerializableValue


### PR DESCRIPTION
as a fix to error below while using redux-persist :

`A non-serializable value was detected in an action, in the path: register...`

I tried to add an `ignoredActions` array for cases like `persist/PERSIST`

a working todo example can be found [here](https://github.com/ramyareye/rsk-convert-todos-example)

fixes #121
fixes #150
fixes rt2zz/redux-persist#988