### PR TITLE
Add example Todo-App repo link

### DIFF
--- a/docs/usage/examples.md
+++ b/docs/usage/examples.md
@@ -25,6 +25,8 @@ for now until we have a chance to specifically create some examples
 
 ## Example Projects
 
+Simple Todo-App using Typescript, latest React Hooks syntax, React-Bootstrap and persisted store to localStorage: [JamesInnes2169/todo-app-react-hooks-redux](https://github.com/JamesInnes2169/todo-app-react-hooks-redux)
+
 Mark Erikson has converted a couple of other people's projects to use Redux Starter Kit, to help show the process
 and how much simpler the code can be when using RSK.
 


### PR DESCRIPTION
While @markerikson is a legend and the repo he converted [rsk-convert-todos-example](https://github.com/markerikson/rsk-convert-todos-example/) is rather helpful it doesn't make use of the latest React syntax with hooks and isn't help with Typescript. Hopefully this very simple example can help people overcome any friction in implementing rsk into projects using hooks. 😊