### PR TITLE
Remove Selectorator

### DIFF
--- a/docs/api/createSelector.md
+++ b/docs/api/createSelector.md
@@ -7,46 +7,14 @@ hide_title: true
 
 # `createSelector`
 
-The `createSelector` utility from the [`selectorator` library](https://github.com/planttheidea/selectorator), re-exported for ease of use. It acts as a superset of the standard `createSelector` function from [Reselect](https://github.com/reactjs/reselect). The primary improvements are the ability to define "input selectors" using string keypaths, or return an object result based on an object of keypaths. It also accepts an object of customization options for more specific use cases.
+The `createSelector` utility from the [Reselect library](https://github.com/reduxjs/reselect), re-exported for ease of use.
 
-For more specifics, see the [`selectorator` usage documentation](https://github.com/planttheidea/selectorator#usage).
+For more details on using `createSelector`, see:
 
-```ts
-function createSelector(
-  // Can either be:
-  //    - An array containing selector functions, string keypaths, and argument objects
-  //    - An object whose keys are selector functions and string keypaths
-  paths: Array<Function | string | Object> | Object<string, string | Function>
-)
-```
+- The [Reselect API documentation](https://github.com/reduxjs/reselect)
+- [Idiomatic Redux: Using Reselect Selectors for Encapsulation and Performance](https://blog.isquaredsoftware.com/2017/12/idiomatic-redux-using-reselect-selectors/)
+- [React/Redux Links: Reducers and Selectors](https://github.com/markerikson/react-redux-links/blob/master/redux-reducers-selectors.md)
 
-Example usage:
-
-```js
-// Define input selector using a string keypath
-const getSubtotal = createSelector(
-  ['shop.items'],
-  items => {
-    // return value here
-  }
-)
-
-// Define input selectors as a mix of other selectors and string keypaths
-const getTax = createSelector(
-  [getSubtotal, 'shop.taxPercent'],
-  (subtotal, taxPercent) => {
-    // return value here
-  }
-)
-
-// Define input selector using a custom argument index to access a prop
-const getTabContent = createSelector(
-  [{ path: 'tabIndex', argIndex: 1 }],
-  tabIndex => {
-    // return value here
-  }
-)
-
-const getContents = createSelector({ foo: 'foo', bar: 'nested.bar' })
-// Returns an object like:  {foo, bar}
-```
+> **Note**: Prior to v0.7, RSK re-exported `createSelector` from [`selectorator`](https://github.com/planttheidea/selectorator), which
+> allowed using string keypaths as input selectors. This was removed, as it ultimately did not provide enough benefits, and
+> the string keypaths made static typing for selectors difficult.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2351,11 +2351,6 @@
         "cssom": "0.3.x"
       }
     },
-    "curriable": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/curriable/-/curriable-1.2.5.tgz",
-      "integrity": "sha512-hQwrkCn8DNiCw5CG8OS0td2wfpCDtxo1dmrVYxCDWUBHQPkpAvN9RqBVbmC64oSQaBqPQD2SOCXcTWH1zXe2mA=="
-    },
     "damerau-levenshtein": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
@@ -3100,11 +3095,6 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
-    },
-    "fast-equals": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-1.6.2.tgz",
-      "integrity": "sha512-6FiKwHkrHIqdvo9I92yzCR/zuWE6iy5ldcOszStPbmo7Zzj3OoVeng++GE//JqO4i6JQ4vH/BVAfCmUCki+C3g=="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -3986,14 +3976,6 @@
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "identitate": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/identitate/-/identitate-1.0.1.tgz",
-      "integrity": "sha512-xnDJ0JYhiZjBDuJRKbHoVzj5yP9FhATxLyUYswQyPdnJrwzGVBqS6DOmvKJi1lk7P+4dkL+hhUhuOZIcOUtG5A==",
-      "requires": {
-        "pathington": "^1.0.1"
       }
     },
     "ignore": {
@@ -5735,11 +5717,6 @@
         "pify": "^2.0.0"
       }
     },
-    "pathington": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/pathington/-/pathington-1.1.7.tgz",
-      "integrity": "sha512-JxzhUzagDfNIOm4qqwQqP3rWeo7rNNOfIahy4n+3GTEdwXLqw5cJHUR0soSopQtNEv763lzxb6eA2xBllpR8zw=="
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -6436,17 +6413,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "selectorator": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/selectorator/-/selectorator-4.0.3.tgz",
-      "integrity": "sha512-A8+paRhzTab4Qm/38RAVnCgEZFbpn5xIWLyTCDqvyU3Obhmo94RS6UK1H00bVH7+U609sOhqbFJha09POsWURA==",
-      "requires": {
-        "fast-equals": "^1.2.1",
-        "identitate": "^1.0.0",
-        "reselect": "^4.0.0",
-        "unchanged": "^2.0.1"
       }
     },
     "semver": {
@@ -7246,15 +7212,6 @@
           "dev": true,
           "optional": true
         }
-      }
-    },
-    "unchanged": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/unchanged/-/unchanged-2.1.0.tgz",
-      "integrity": "sha512-CYVU0Mz35N821Pjxf+iG6JMPx/Yb6wStUq8uuhR52/+AU3vMiueOTrJ6u1vBKYSke7a75FAi2/jCdQkXcHaNGQ==",
-      "requires": {
-        "curriable": "^1.2.4",
-        "pathington": "^1.1.5"
       }
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "redux-devtools-extension": "^2.13.8",
     "redux-immutable-state-invariant": "^2.1.0",
     "redux-thunk": "^2.2.0",
-    "selectorator": "^4.0.3"
+    "reselect": "^4.0.0"
   },
   "jest": {
     "testEnvironment": "node",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { combineReducers, compose } from 'redux'
 export { default as createNextState } from 'immer'
-export { default as createSelector } from 'selectorator'
+export { createSelector } from 'reselect'
 
 export * from './configureStore'
 export * from './createAction'

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -10,6 +10,6 @@ export {
   compose
 } from 'redux'
 export { default as createNextState } from 'immer'
-export { default as createSelector } from 'selectorator'
+export { default as createSelector } from 'reselect'
 
 export * from '.'

--- a/type-tests/files/createSlice.typetest.ts
+++ b/type-tests/files/createSlice.typetest.ts
@@ -125,7 +125,7 @@ function expectType<T>(t: T) {
 {
   const counter = createSlice({
     slice: 'test',
-    initialState: { counter: 0, concat: "" },
+    initialState: { counter: 0, concat: '' },
     reducers: {
       incrementByStrLen: {
         reducer: (state, action: PayloadAction<number>) => {


### PR DESCRIPTION
Dropping Selectorator, because string keypaths lose type safety, and there's not enough real benefit.

Reference:

https://twitter.com/acemarke/status/1086708785610149889