### PR TITLE
Add explanation of the second argument of createAction to the API docs

### DIFF
--- a/docs/api/createAction.md
+++ b/docs/api/createAction.md
@@ -10,7 +10,7 @@ hide_title: true
 A helper function for defining a Redux [action](https://redux.js.org/basics/actions) type and creator.
 
 ```js
-function createAction(type)
+function createAction(type, prepareAction?)
 ```
 
 The usual way to define an action in Redux is to separately declare an _action type_ constant and an _action creator_ function for constructing actions of that type.
@@ -46,6 +46,40 @@ console.log(increment.toString())
 console.log(`The action type is: ${increment}`)
 // 'The action type is: counter/increment'
 ```
+
+## Using the optional second argument
+
+In cases where you want to create actions with some logic (e.g. generating a random ID in the action creator or getting the current date), you can use the second argument to `createAction` to provide this logic.
+
+```js
+import v4 from 'uuid/v4'
+
+const addTodo = createAction('todos/add', function prepare(text) {
+  return {
+    payload: {
+      text,
+      id: v4(),
+      createdAt: new Date().toISOString()
+    }
+  }
+})
+
+console.log(addTodo('Write more docs'))
+/**
+ * {
+ *   type: 'todos/add',
+ *   payload: {
+ *     text: 'Write more docs',
+ *     id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+ *     createdAt: '2019-10-03T07:53:36.581Z'
+ *   }
+ * }
+ **/
+```
+
+The prepare function must return an object with a payload field (otherwise the payload of created actions will be `undefined`). Additionally, the object can have a field `meta` that will also be added to created actions. This may contain extra information about the action. These two fields (payload and meta) adhere to the specification of [Flux Standard Actions](https://github.com/redux-utilities/flux-standard-action#actions).
+
+**Note:** The type field will be added automatically.
 
 ## Usage with createReducer()
 

--- a/docs/api/createAction.md
+++ b/docs/api/createAction.md
@@ -47,9 +47,11 @@ console.log(`The action type is: ${increment}`)
 // 'The action type is: counter/increment'
 ```
 
-## Using the optional second argument
+## Using Prepare Callbacks to Customize Action Contents
 
-In cases where you want to create actions with some logic (e.g. generating a random ID in the action creator or getting the current date), you can use the second argument to `createAction` to provide this logic.
+By default, the generated action creators accept a single argument, which becomes `action.payload`.  This requires the caller to construct the entire payload correctly and pass it in.
+
+In many cases, you may want to write additional logic to customize the creation of the `payload`  value, such as accepting multiple parameters for the action creator, generating a random ID, or getting the current timestamp.  To do this, `createAction` accepts an optional second argument: a "prepare callback" that will be used to construct the payload value.  
 
 ```js
 import v4 from 'uuid/v4'
@@ -77,7 +79,7 @@ console.log(addTodo('Write more docs'))
  **/
 ```
 
-The prepare function must return an object with a payload field (otherwise the payload of created actions will be `undefined`). Additionally, the object can have a field `meta` that will also be added to created actions. This may contain extra information about the action. These two fields (payload and meta) adhere to the specification of [Flux Standard Actions](https://github.com/redux-utilities/flux-standard-action#actions).
+If provided, all arguments from the action creator will be passed to the prepare callback, and it should return an object with the `payload` field (otherwise the payload of created actions will be `undefined`). Additionally, the object can have a `meta` field that will also be added to created actions. This may contain extra information about the action. These two fields (`payload` and `meta`) adhere to the specification of [Flux Standard Actions](https://github.com/redux-utilities/flux-standard-action#actions).
 
 **Note:** The type field will be added automatically.
 


### PR DESCRIPTION
I noticed that this argument was mentioned in the Intermedia Tutorial but not listed in the API docs. I'm not sure if this is intentional. If not, I started this PR to discuss possible explanations for this section of the docs.