### PR TITLE
Fix createSlice.md typing typo

### DIFF
--- a/docs/api/createSlice.md
+++ b/docs/api/createSlice.md
@@ -75,7 +75,7 @@ to force the TS compiler to accept the computed property.)
 {
     slice : string,
     reducer : ReducerFunction,
-    actions : Object<string, ActionCreator},
+    actions : Object<string, ActionCreator>,
 }
 ```
 


### PR DESCRIPTION
This fixes the typo from #186.