### PR TITLE
Update usage-guide.md to reflect updates

### DIFF
--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -288,7 +288,7 @@ addTodo({ text: 'Buy milk' })
 // {type : "ADD_TODO", payload : {text : "Buy milk"}})
 ```
 
-`createAction` also accepts a prepare callback which allows you to customize the resulting action contents and add other fields like `meta`. Refer to the `prepare` callback spec [here](https://redux-starter-kit.js.org/api/createaction#using-prepare-callbacks-to-customize-action-contents).
+`createAction` also accepts a "prepare callback" argument, which allows you to customize the resulting `payload` field and optionally add a `meta` field. See the [`createAction` API reference](https://redux-starter-kit.js.org/api/createaction#using-prepare-callbacks-to-customize-action-contents) for details on defining action creators with a prepare callback.
 
 ### Using Action Creators as Action Types
 

--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -288,7 +288,7 @@ addTodo({ text: 'Buy milk' })
 // {type : "ADD_TODO", payload : {text : "Buy milk"}})
 ```
 
-Currently, `createAction` does not let you customize how the `payload` field is defined. You need to pass the entire `payload` you want as the one argument to the action creator. This could be a simple value, or an object full of data. (We may eventually add the ability for `createAction` to accept an argument for a callback that customizes the payload, or allows adding other fields like `meta` to the action.)
+`createAction` also accepts a prepare callback which allows you to customize the resulting action contents and add other fields like `meta`. Refer to the `prepare` callback spec [here](https://redux-starter-kit.js.org/api/createaction#using-prepare-callbacks-to-customize-action-contents).
 
 ### Using Action Creators as Action Types
 


### PR DESCRIPTION
I think the `createAction` function has since been updated to support `prepare` for adding attributes like `meta` to an action. Updating documentation so users don't get discouraged and think they can't use `meta` along with `redux-starter-kit`. (This was the first page I landed on when searching how to add `meta` in conjunction with this library and almost thought I'd need to abandon my work on migrating :yikes:)

Edit: and of course, thank you so much for creating this repo! Currently migrating an internal application that I inherited with a bunch of hand-made types and inconsistent reducer structuring which I'm hoping this will help address 🎉 