### PR TITLE
Use TypeScript 3.6 in development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7173,9 +7173,9 @@
       }
     },
     "typescript": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
-      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
       "dev": true
     },
     "typings-tester": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-strip-code": "^0.2.6",
     "rollup-plugin-terser": "^5.1.1",
-    "typescript": "^3.4.3",
+    "typescript": "^3.6.4",
     "typings-tester": "^0.3.2"
   },
   "scripts": {


### PR DESCRIPTION
I originally meant to include this in #217.

ESLint now gives a warning but I tried to update `typescript-eslint` and it doesn't seem to be supported yet.