### PR TITLE
feat(action): support optional error field

### DIFF
--- a/docs/api/createAction.md
+++ b/docs/api/createAction.md
@@ -79,7 +79,7 @@ console.log(addTodo('Write more docs'))
  **/
 ```
 
-If provided, all arguments from the action creator will be passed to the prepare callback, and it should return an object with the `payload` field (otherwise the payload of created actions will be `undefined`). Additionally, the object can have a `meta` field that will also be added to created actions. This may contain extra information about the action. These two fields (`payload` and `meta`) adhere to the specification of [Flux Standard Actions](https://github.com/redux-utilities/flux-standard-action#actions).
+If provided, all arguments from the action creator will be passed to the prepare callback, and it should return an object with the `payload` field (otherwise the payload of created actions will be `undefined`). Additionally, the object can have a `meta` and/or an `error` field that will also be added to created actions. `meta` may contain extra information about the action, `error` may contain details about the action failure. These three fields (`payload`, `meta` and `error`) adhere to the specification of [Flux Standard Actions](https://github.com/redux-utilities/flux-standard-action#actions).
 
 **Note:** The type field will be added automatically.
 

--- a/src/createAction.test.ts
+++ b/src/createAction.test.ts
@@ -48,6 +48,50 @@ describe('createAction', () => {
     })
   })
 
+  describe('when passing a prepareAction method returning a payload and error', () => {
+    it('should use the payload returned from the prepareAction method', () => {
+      const actionCreator = createAction('A_TYPE', (a: number) => ({
+        payload: a * 2,
+        error: true
+      }))
+      expect(actionCreator(5).payload).toBe(10)
+    })
+    it('should use the error returned from the prepareAction method', () => {
+      const actionCreator = createAction('A_TYPE', (a: number) => ({
+        payload: a * 2,
+        error: true
+      }))
+      expect(actionCreator(10).error).toBe(true)
+    })
+  })
+
+  describe('when passing a prepareAction method returning a payload, meta and error', () => {
+    it('should use the payload returned from the prepareAction method', () => {
+      const actionCreator = createAction('A_TYPE', (a: number) => ({
+        payload: a * 2,
+        meta: a / 2,
+        error: true
+      }))
+      expect(actionCreator(5).payload).toBe(10)
+    })
+    it('should use the error returned from the prepareAction method', () => {
+      const actionCreator = createAction('A_TYPE', (a: number) => ({
+        payload: a * 2,
+        meta: a / 2,
+        error: true
+      }))
+      expect(actionCreator(10).error).toBe(true)
+    })
+    it('should use the meta returned from the prepareAction method', () => {
+      const actionCreator = createAction('A_TYPE', (a: number) => ({
+        payload: a * 2,
+        meta: a / 2,
+        error: true
+      }))
+      expect(actionCreator(10).meta).toBe(5)
+    })
+  })
+
   describe('when passing a prepareAction that accepts multiple arguments', () => {
     it('should pass all arguments of the resulting actionCreator to prepareAction', () => {
       const actionCreator = createAction(

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -156,6 +156,8 @@ function expectType<T>(p: T): T {
 
   // typings:expect-error
   expectType<string>(strLenAction('test').payload)
+  // typings:expect-error
+  expectType<boolean>(strLenAction('test').error)
 }
 
 /*
@@ -171,6 +173,38 @@ function expectType<T>(p: T): T {
 
   // typings:expect-error
   expectType<string>(strLenMetaAction('test').meta)
+  // typings:expect-error
+  expectType<boolean>(strLenMetaAction('test').error)
+}
+
+/*
+ * Test: adding boolean error with prepareAction
+ */
+{
+  const boolErrorAction = createAction('boolError', (payload: string) => ({
+    payload,
+    error: true
+  }))
+
+  expectType<boolean>(boolErrorAction('test').error)
+
+  // typings:expect-error
+  expectType<string>(boolErrorAction('test').error)
+}
+
+/*
+ * Test: adding string error with prepareAction
+ */
+{
+  const strErrorAction = createAction('strError', (payload: string) => ({
+    payload,
+    error: 'this is an error'
+  }))
+
+  expectType<string>(strErrorAction('test').error)
+
+  // typings:expect-error
+  expectType<boolean>(strErrorAction('test').error)
 }
 
 /*

--- a/type-tests/files/createAction.typetest.ts
+++ b/type-tests/files/createAction.typetest.ts
@@ -157,7 +157,7 @@ function expectType<T>(p: T): T {
   // typings:expect-error
   expectType<string>(strLenAction('test').payload)
   // typings:expect-error
-  expectType<boolean>(strLenAction('test').error)
+  const error: any = strLenAction('test').error
 }
 
 /*
@@ -174,7 +174,7 @@ function expectType<T>(p: T): T {
   // typings:expect-error
   expectType<string>(strLenMetaAction('test').meta)
   // typings:expect-error
-  expectType<boolean>(strLenMetaAction('test').error)
+  const error: any = strLenMetaAction('test').error
 }
 
 /*


### PR DESCRIPTION
Allow `prepareAction` to return an optional `error` field as per the Flux specification
https://github.com/redux-utilities/flux-standard-action#actions