### PR TITLE
also run travis tests with the current release candidate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js: node
 env:
+  - TYPESCRIPT_VERSION=rc
   - TYPESCRIPT_VERSION=3.6
   - TYPESCRIPT_VERSION=3.5
   - TYPESCRIPT_VERSION=3.4


### PR DESCRIPTION
It might be a good idea to always run the tests with the current upcoming RC to be braced for breaking changes.