### PR TITLE
Integrate Codesandbox CI

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,0 +1,10 @@
+{
+  // a list of sandboxes that you want generated for a PR, if this list
+  // is not set we will default to `vanilla`. The built library will automatically
+  // be installed in the fork of these sandboxes.
+  "sandboxes": [
+    "vanilla",
+    "vanilla-ts",
+    "github/reduxjs/rsk-github-issues-example"
+  ]
+}


### PR DESCRIPTION
This would give us a build and a Codesandbox to play around with it for every Pull Request.

You can find more information here. https://u2edh.csb.app/

Aside from merging this PR, you'd need to add the [github app](https://github.com/apps/codesandbox) to this repository. Once that's done I can ping the ppl over at CodeSandbox and they'd whitelist the repo, enabling everything.

What do you think?