### PR TITLE
Remove the unused `ActionCreator` import in the tutorial doc

### DIFF
--- a/docs/tutorials/advanced-tutorial.md
+++ b/docs/tutorials/advanced-tutorial.md
@@ -520,7 +520,7 @@ Before we go any further, let's add a type declaration we can reuse instead.
 
 ```diff
 -import { configureStore } from 'redux-starter-kit'
-+import { configureStore, ActionCreator, Action } from 'redux-starter-kit'
++import { configureStore, Action } from 'redux-starter-kit'
 +import { ThunkAction } from 'redux-thunk'
 
 -import rootReducer from './rootReducer'


### PR DESCRIPTION
The `ActionCreator` import in the **app/store.ts** diff is not needed and can be removed. I have double-checked it by looking at the [commit](https://github.com/reduxjs/rsk-github-issues-example/commit/2ac93bb089705847a8ce349864d885a5039eff4b) of adding AppThunk type.

Please review and merge. Thanks!